### PR TITLE
httpd: added ability to configure different credentials per listener

### DIFF
--- a/include/seastar/core/rwlock.hh
+++ b/include/seastar/core/rwlock.hh
@@ -146,7 +146,7 @@ public:
     /// return an exceptional future) when it failed to obtain the lock -
     /// e.g., on allocation failure.
     future<holder> hold_read_lock(typename semaphore_type::time_point timeout = semaphore_type::time_point::max()) {
-        return get_units(_sem, 1);
+        return get_units(_sem, 1, timeout);
     }
 
     /// hold_write_lock() waits for a write lock and returns an object which,
@@ -161,7 +161,7 @@ public:
     /// return an exceptional future) when it failed to obtain the lock -
     /// e.g., on allocation failure.
     future<holder> hold_write_lock(typename semaphore_type::time_point timeout = semaphore_type::time_point::max()) {
-        return get_units(_sem, max_ops);
+        return get_units(_sem, max_ops, timeout);
     }
 
     /// Checks if any read or write locks are currently held.

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -186,6 +186,8 @@ public:
 
     void set_content_streaming(bool b);
 
+    future<> listen(socket_address addr, shared_ptr<seastar::tls::server_credentials> credentials);
+    future<> listen(socket_address addr, listen_options lo, shared_ptr<seastar::tls::server_credentials> credentials);
     future<> listen(socket_address addr, listen_options lo);
     future<> listen(socket_address addr);
     future<> stop();

--- a/include/seastar/util/concepts.hh
+++ b/include/seastar/util/concepts.hh
@@ -20,7 +20,8 @@
  */
 #pragma once
 
-#if defined(__cpp_concepts) && __cpp_concepts >= 201907
+#if defined(__cpp_concepts) && __cpp_concepts >= 201907 && \
+    defined(__cpp_lib_concepts) && __cpp_lib_concepts >= 201907
 
 #define SEASTAR_CONCEPT(x...) x
 #define SEASTAR_NO_CONCEPT(x...)


### PR DESCRIPTION
For some deployments it may be required to configure different set of
credentials for different http server listeners. Added ability to
set/override default http server credentials with listener specific set
of credentials.

Signed-off-by: Michal Maslanka <michal@vectorized.io>