### PR TITLE
coroutine: further restrict future<void> case for gcc >= 10.2.1

### DIFF
--- a/include/seastar/core/coroutine.hh
+++ b/include/seastar/core/coroutine.hh
@@ -87,8 +87,8 @@ public:
             _promise.set_value();
         }
 
-// Only accepted in gcc 10; the standard says it is illegal
-#if !defined(__clang__) && __GNUC__  < 11
+// Only accepted in gcc 10-10.2.0; the standard says it is illegal
+#if !defined(__clang__) && (__GNUC__  < 11 && __GNUC_MINOR__ < 3 && __GNUC_PATCHLEVEL__ < 1)
         [[deprecated("forwarding a future<> is not possible in standard C++. 'Use co_return co_wait ...' instead.")]]
         void return_value(future<>&& fut) noexcept {
             fut.forward_to(std::move(_promise));


### PR DESCRIPTION
The syntax is not legal. gcc 10.2.0 accepts it, but 10.2.1 rejects it.

Signed-off-by: Ben Pope <ben@vectorized.io>