### PR TITLE
Httpd request context

### DIFF
--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -75,11 +75,12 @@ class connection : public boost::intrusive::list_base_hook<> {
     queue<std::unique_ptr<reply>> _replies { 10 };
     bool _done = false;
     bool _tls;
+    int _listener_idx;
 public:
     connection(http_server& server, connected_socket&& fd,
-            socket_address addr, bool tls)
+            socket_address addr, bool tls, int listener_idx)
             : _server(server), _fd(std::move(fd)), _read_buf(_fd.input()), _write_buf(
-                    _fd.output()), _tls(tls) {
+                    _fd.output()), _tls(tls), _listener_idx(listener_idx) {
         on_new_connection();
     }
     ~connection();

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -242,7 +242,9 @@ public:
     future<> stop();
     future<> set_routes(std::function<void(routes& r)> fun);
     future<> listen(socket_address addr);
+    future<> listen(socket_address addr, shared_ptr<seastar::tls::server_credentials> credentials);
     future<> listen(socket_address addr, listen_options lo);
+    future<> listen(socket_address addr, listen_options lo, shared_ptr<seastar::tls::server_credentials> credentials);
     distributed<http_server>& server();
 };
 

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -74,11 +74,12 @@ class connection : public boost::intrusive::list_base_hook<> {
     // null element marks eof
     queue<std::unique_ptr<reply>> _replies { 10 };
     bool _done = false;
+    bool _tls;
 public:
     connection(http_server& server, connected_socket&& fd,
-            socket_address addr)
+            socket_address addr, bool tls)
             : _server(server), _fd(std::move(fd)), _read_buf(_fd.input()), _write_buf(
-                    _fd.output()) {
+                    _fd.output()), _tls(tls) {
         on_new_connection();
     }
     ~connection();
@@ -186,11 +187,13 @@ public:
 
     void set_content_streaming(bool b);
 
+    future<> listen(socket_address addr, shared_ptr<seastar::tls::server_credentials> credentials);
+    future<> listen(socket_address addr, listen_options lo, shared_ptr<seastar::tls::server_credentials> credentials);
     future<> listen(socket_address addr, listen_options lo);
     future<> listen(socket_address addr);
     future<> stop();
 
-    future<> do_accepts(int which);
+    future<> do_accepts(int which, bool tls = false);
 
     uint64_t total_connections() const;
     uint64_t current_connections() const;
@@ -201,7 +204,7 @@ public:
     // RFC 7231, Section 7.1.1.1.
     static sstring http_date();
 private:
-    future<> do_accept_one(int which);
+    future<> do_accept_one(int which, bool tls);
     boost::intrusive::list<connection> _connections;
     friend class seastar::httpd::connection;
     friend class http_server_tester;

--- a/include/seastar/http/request.hh
+++ b/include/seastar/http/request.hh
@@ -87,7 +87,7 @@ struct request {
     std::unordered_map<sstring, sstring> trailing_headers;
     std::unordered_map<sstring, sstring> chunk_extensions;
     sstring protocol_name = "http";
-
+    int listener_idx;
     /**
      * Search for the first header of a given name
      * @param name the header name
@@ -135,6 +135,13 @@ struct request {
 
     bool is_form_post() const {
         return content_type_class == ctclass::app_x_www_urlencoded;
+    }
+    /**
+     * Get index of listener which accepted connection receiving this request
+     * @return position of listener in server _listeners vector
+     */
+    int get_listener_idx() const {
+        return listener_idx;
     }
 
 };

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -599,8 +599,16 @@ future<> http_server_control::listen(socket_address addr) {
     return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address)>(&http_server::listen, addr);
 }
 
+future<> http_server_control::listen(socket_address addr, shared_ptr<seastar::tls::server_credentials> credentials) {
+    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, shared_ptr<seastar::tls::server_credentials>)>(&http_server::listen, addr, credentials);
+}
+
 future<> http_server_control::listen(socket_address addr, listen_options lo) {
     return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, listen_options)>(&http_server::listen, addr, lo);
+}
+
+future<> http_server_control::listen(socket_address addr, listen_options lo, shared_ptr<seastar::tls::server_credentials> credentials) {
+    return _server_dist->invoke_on_all<future<> (http_server::*)(socket_address, listen_options, shared_ptr<seastar::tls::server_credentials>)>(&http_server::listen, addr, lo, credentials);
 }
 
 distributed<http_server>& http_server_control::server() {

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -228,7 +228,7 @@ future<> connection::read_one() {
         }
         ++_server._requests_served;
         std::unique_ptr<httpd::request> req = _parser.get_parsed_request();
-        if (_server._credentials) {
+        if (_tls) {
             req->protocol_name = "https";
         }
         if (_parser.failed()) {
@@ -473,14 +473,28 @@ void http_server::set_content_streaming(bool b) {
     _content_streaming = b;
 }
 
-future<> http_server::listen(socket_address addr, listen_options lo) {
-    if (_credentials) {
-        _listeners.push_back(seastar::tls::listen(_credentials, addr, lo));
+future<> http_server::listen(socket_address addr, listen_options lo, 
+            shared_ptr<seastar::tls::server_credentials> listener_credentials) {
+    
+    if (listener_credentials) {
+        _listeners.push_back(seastar::tls::listen(listener_credentials, addr, lo));
     } else {
         _listeners.push_back(seastar::listen(addr, lo));
     }
-    return do_accepts(_listeners.size() - 1);
+    return do_accepts(_listeners.size() - 1, listener_credentials != nullptr);
 }
+
+future<> http_server::listen(socket_address addr, listen_options lo) {
+    return listen(addr, lo, _credentials);
+}
+
+future<> http_server::listen(socket_address addr, 
+            shared_ptr<seastar::tls::server_credentials> listener_credentials) {
+    listen_options lo;
+    lo.reuse_address = true;
+    return listen(addr, lo, listener_credentials);
+}
+
 future<> http_server::listen(socket_address addr) {
     listen_options lo;
     lo.reuse_address = true;
@@ -498,20 +512,21 @@ future<> http_server::stop() {
 }
 
 // FIXME: This could return void
-future<> http_server::do_accepts(int which) {
-    (void)try_with_gate(_task_gate, [this, which] {
-        return keep_doing([this, which] {
-            return try_with_gate(_task_gate, [this, which] {
-                return do_accept_one(which);
+future<> http_server::do_accepts(int which, bool tls) {
+    (void)try_with_gate(_task_gate, [this, which, tls] {
+        return keep_doing([this, which, tls] {
+            return try_with_gate(_task_gate, [this, which, tls] {
+                return do_accept_one(which, tls);
             });
         }).handle_exception_type([](const gate_closed_exception& e) {});
     }).handle_exception_type([](const gate_closed_exception& e) {});
     return make_ready_future<>();
 }
 
-future<> http_server::do_accept_one(int which) {
-    return _listeners[which].accept().then([this] (accept_result ar) mutable {
-        auto conn = std::make_unique<connection>(*this, std::move(ar.connection), std::move(ar.remote_address));
+future<> http_server::do_accept_one(int which, bool tls) {
+    return _listeners[which].accept().then([this, tls] (accept_result ar) mutable {
+        auto conn = std::make_unique<connection>(*this, std::move(ar.connection), 
+                            std::move(ar.remote_address), tls);
         (void)try_with_gate(_task_gate, [conn = std::move(conn)]() mutable {
             return conn->process().handle_exception([conn = std::move(conn)] (std::exception_ptr ex) {
                 hlogger.error("request error: {}", ex);

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -228,6 +228,7 @@ future<> connection::read_one() {
         }
         ++_server._requests_served;
         std::unique_ptr<httpd::request> req = _parser.get_parsed_request();
+        req->listener_idx = _listener_idx;
         if (_tls) {
             req->protocol_name = "https";
         }
@@ -524,9 +525,9 @@ future<> http_server::do_accepts(int which, bool tls) {
 }
 
 future<> http_server::do_accept_one(int which, bool tls) {
-    return _listeners[which].accept().then([this, tls] (accept_result ar) mutable {
+    return _listeners[which].accept().then([this, tls, which] (accept_result ar) mutable {
         auto conn = std::make_unique<connection>(*this, std::move(ar.connection), 
-                            std::move(ar.remote_address), tls);
+                            std::move(ar.remote_address), tls, which);
         (void)try_with_gate(_task_gate, [conn = std::move(conn)]() mutable {
             return conn->process().handle_exception([conn = std::move(conn)] (std::exception_ptr ex) {
                 hlogger.error("request error: {}", ex);


### PR DESCRIPTION
Added per listener TLS setup (fixed recognizing protocol schema) and ability to recognize which listener accepted given connection. This feature is needed for the Kafka-Rest compatibility proxy in redpanda as we need to return a contextual information based on HTTP or HTTPS as per the protocol description and need underlying access to the actual listener information.

