### PR TITLE
httpd: add status_type 409

### DIFF
--- a/include/seastar/http/reply.hh
+++ b/include/seastar/http/reply.hh
@@ -66,6 +66,7 @@ struct reply {
         forbidden = 403, //!< forbidden
         not_found = 404, //!< not_found
         not_acceptable = 406, //!< not_acceptable
+        conflict = 409, //!< conflict
         length_required = 411, //!< length_required
         payload_too_large = 413, //!< payload_too_large
         unsupported_media_type = 415, //!< unsupported_media_type

--- a/src/http/reply.cc
+++ b/src/http/reply.cc
@@ -53,6 +53,7 @@ const sstring unauthorized = " 401 Unauthorized\r\n";
 const sstring forbidden = " 403 Forbidden\r\n";
 const sstring not_found = " 404 Not Found\r\n";
 const sstring not_acceptable = " 406 Not Acceptable\r\n";
+const sstring conflict = " 409 Conflict\r\n";
 const sstring length_required = " 411 Length Required\r\n";
 const sstring payload_too_large = " 413 Payload Too Large\r\n";
 const sstring unsupported_media_type = " 415 Unsupported Media Type\r\n";
@@ -92,6 +93,8 @@ static const sstring& to_string(reply::status_type status) {
         return not_found;
     case reply::status_type::not_acceptable:
         return not_acceptable;
+    case reply::status_type::conflict:
+        return conflict;
     case reply::status_type::length_required:
         return length_required;
     case reply::status_type::payload_too_large:


### PR DESCRIPTION
Adding `409 Conflict` status

A 409 can be returned when a POST is received for an object that already exists (https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto#L80).

For example a request to `v1/security/users` to create an existing user would return a 409. The following commit on the redpanda side would do this: https://github.com/dimitriscruz/redpanda/commit/cb9562c1bac3b409deeda9efb0ff378bf55dbc6d

Eventually, the 409 code would be used by the k8s operator to detect the existence of a user and stop trying to create one without having to do a GET or parse the returned message.

Note: I'm creating this PR against branch `httpd` because it is the one used when compiling redpanda (3rd party - vtools/cmake/3rdparty.cmake.in). The `master` branch does not work with redpanda:dev.