### PR TITLE
http: permit custom status on redirect_exception

### DIFF
--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -61,8 +61,8 @@ private:
  */
 class redirect_exception : public base_exception {
 public:
-    redirect_exception(const std::string& url)
-            : base_exception("", reply::status_type::moved_permanently), url(
+    redirect_exception(const std::string& url, reply::status_type status = reply::status_type::moved_permanently)
+            : base_exception("", status), url(
                     url) {
     }
     std::string url;


### PR DESCRIPTION
There are various 3xx statuses we might want instead
of the default 301.

Signed-off-by: John Spray <jcs@vectorized.io>