### PR TITLE
http: make redirect_exception work from inside futures

### DIFF
--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -37,6 +37,17 @@ void verify_param(const request& req, const sstring& param) {
     }
 }
 routes::routes() : _general_handler([this](std::exception_ptr eptr) mutable {
+    try {
+        std::rethrow_exception(eptr);
+    } catch (const redirect_exception& _e) {
+        auto rep = std::make_unique<reply>();
+        rep->add_header("Location", _e.url).set_status(_e.status()).done(
+                "json");
+        return rep;
+    } catch (...) {
+        // Fall through to return exception reply
+    }
+
     return exception_reply(eptr);
 }) {}
 


### PR DESCRIPTION
Previously this was only handled from synchronous
code inside a handler, not when thrown from inside
the future returned by the handler.

Signed-off-by: John Spray <jcs@vectorized.io>