### PR TITLE
http: add ability to pass response bodies in `base_exception`

### DIFF
--- a/include/seastar/http/exception.hh
+++ b/include/seastar/http/exception.hh
@@ -39,6 +39,15 @@ public:
             : _msg(msg), _status(status) {
     }
 
+    /**
+     * A base_exception with a content_type is specifying a full response body, whereas
+     * a base_exception with only a _status is specifying a string that may be wrapped
+     * in e.g. a json_exception.
+     */
+    base_exception(const std::string& msg, reply::status_type status, const std::string &content_type)
+            : _msg(msg), _status(status), _content_type(content_type) {
+    }
+
     virtual const char* what() const throw () {
         return _msg.c_str();
     }
@@ -50,9 +59,14 @@ public:
     virtual const std::string& str() const {
         return _msg;
     }
+
+    virtual const std::string& content_type() const {
+        return _content_type;
+    }
 private:
     std::string _msg;
     reply::status_type _status;
+    std::string _content_type;
 
 };
 

--- a/include/seastar/http/httpd.hh
+++ b/include/seastar/http/httpd.hh
@@ -123,7 +123,7 @@ public:
     static sstring set_query_param(request& req);
 
     future<bool> generate_reply(std::unique_ptr<request> req);
-    void generate_error_reply_and_close(std::unique_ptr<request> req, reply::status_type status, const sstring& msg);
+    void generate_error_reply_and_close(std::unique_ptr<request> req, reply::status_type status, const sstring& msg, const sstring &content_type={});
 
     future<> write_body();
 

--- a/src/http/httpd.cc
+++ b/src/http/httpd.cc
@@ -210,11 +210,14 @@ set_request_content(std::unique_ptr<httpd::request> req, input_stream<char>* con
     }
 }
 
-void connection::generate_error_reply_and_close(std::unique_ptr<httpd::request> req, reply::status_type status, const sstring& msg) {
+void connection::generate_error_reply_and_close(std::unique_ptr<httpd::request> req, reply::status_type status, const sstring& msg, const sstring &content_type) {
     auto resp = std::make_unique<reply>();
     // TODO: Handle HTTP/2.0 when it releases
     resp->set_version(req->_version);
     resp->set_status(status, msg);
+    if (!content_type.empty()) {
+        resp->set_content_type(content_type);
+    }
     resp->done();
     _done = true;
     _replies.push(std::move(resp));
@@ -297,7 +300,7 @@ future<> connection::read_one() {
                     // before passing the request to handler - when we were parsing chunks
                     auto err_req = std::make_unique<httpd::request>();
                     err_req->_version = version;
-                    generate_error_reply_and_close(std::move(err_req), e.status(), e.str());
+                    generate_error_reply_and_close(std::move(err_req), e.status(), e.str(), e.content_type());
                 });
             });
         });

--- a/src/http/routes.cc
+++ b/src/http/routes.cc
@@ -82,7 +82,12 @@ std::unique_ptr<reply> routes::exception_reply(std::exception_ptr eptr) {
         }
         std::rethrow_exception(eptr);
     } catch (const base_exception& e) {
-        rep->set_status(e.status(), json_exception(e).to_json());
+        if (e.content_type().size()) {
+            rep->set_status(e.status(), e.str());
+            rep->set_content_type(e.content_type());
+        } else {
+            rep->set_status(e.status(), json_exception(e).to_json());
+        }
     } catch (...) {
         rep->set_status(reply::status_type::internal_server_error,
                 json_exception(std::current_exception()).to_json());


### PR DESCRIPTION
In JSON request handlers, the string carried in the exception would be wrapped in a {"message": <string>, "status": <code>} body.  That prevented sending back a full response body to provide structured errors, e.g. dicts of request attributes to validation issues.

In this PR, a content_type field is added to base_exception, and if this content type is set then the exception's string is used as the full response body, and the response's content type header is set.