### PR TITLE
Seastar changes for abort on OOM

### DIFF
--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -239,6 +239,12 @@ void set_reclaim_hook(
 /// currently alive on this shard.
 void set_abort_on_allocation_failure(bool enabled);
 
+/// \brief Determine the abort on allocation failure mode.
+///
+/// Return true if the global abort on allocation failure behavior
+/// is enabled, or false otherwise. Always returns false if the
+/// default (system) allocator is being used.
+bool is_abort_on_allocation_failure();
 
 class statistics;
 

--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -92,9 +92,11 @@ namespace seastar {
 ///
 /// Often, the best way to debug an allocation failure is a coredump. This
 /// feature allows dumping core on allocation failures, containing the stack of
-/// the failed allocation, by means of aborting. To enable set the
-/// `abort_on_seastar_bad_alloc` configuration option or the respective command
-/// line flag.
+/// the failed allocation, by means of aborting. To enable this behavior, set
+/// `abort_on_seastar_bad_alloc` in `reactor_options` or pass the
+/// `--abort-on-seastar-bad-alloc` command line flag. Additionally, applications
+/// may enable or disable this functionality globally at runtime by calling
+/// `set_abort_on_allocation_failure()`.
 ///
 /// ### Dump diagnostics report
 ///

--- a/include/seastar/core/memory.hh
+++ b/include/seastar/core/memory.hh
@@ -136,6 +136,8 @@ static constexpr size_t huge_page_size =
 void configure(std::vector<resource::memory> m, bool mbind,
         std::optional<std::string> hugetlbfs_path = {});
 
+// A deprecated alias for set_abort_on_allocation_failure(true).
+[[deprecated("use set_abort_on_allocation_failure(true) instead")]]
 void enable_abort_on_allocation_failure();
 
 class disable_abort_on_alloc_failure_temporarily {
@@ -219,6 +221,24 @@ void set_reclaim_hook(
         std::function<void (std::function<void ()>)> hook);
 
 /// \endcond
+
+/// \brief Set the global state of the abort on allocation failure behavior.
+///
+/// If enabled, an allocation failure (i.e., the requested memory
+/// could not be allocated even after reclaim was attempted), will
+/// generally result in `abort()` being called. If disabled, the
+/// failure is reported to the caller, e.g., by throwing a
+/// `std::bad_alloc` for C++ allocations such as new, or returning
+/// a null pointer from malloc.
+///
+/// Note that even if the global state is set to enabled, the
+/// `disable_abort_on_alloc_failure_temporarily` class may override
+/// the behavior tepmorarily on a given shard. That is, abort only
+/// occurs if abort is globablly enabled on this shard _and_ there
+/// are no `disable_abort_on_alloc_failure_temporarily` objects
+/// currently alive on this shard.
+void set_abort_on_allocation_failure(bool enabled);
+
 
 class statistics;
 

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -100,6 +100,10 @@ disable_abort_on_alloc_failure_temporarily::~disable_abort_on_alloc_failure_temp
     --abort_on_alloc_failure_suppressed;
 }
 
+void enable_abort_on_allocation_failure() {
+    set_abort_on_allocation_failure(true);
+}
+
 static std::pmr::polymorphic_allocator<char> static_malloc_allocator{std::pmr::get_default_resource()};;
 std::pmr::polymorphic_allocator<char>* malloc_allocator{&static_malloc_allocator};
 
@@ -1601,8 +1605,8 @@ public:
 static std::atomic<bool> abort_on_allocation_failure{false};
 static std::atomic<alloc_failure_kind> dump_diagnostics_on_alloc_failure_kind{alloc_failure_kind::critical};
 
-void enable_abort_on_allocation_failure() {
-    abort_on_allocation_failure.store(true, std::memory_order_seq_cst);
+void set_abort_on_allocation_failure(bool enabled) {
+    abort_on_allocation_failure.store(enabled, std::memory_order_seq_cst);
 }
 
 void set_dump_memory_diagnostics_on_alloc_failure_kind(alloc_failure_kind kind) {
@@ -2251,8 +2255,11 @@ scoped_heap_profiling::scoped_heap_profiling() noexcept {
 scoped_heap_profiling::~scoped_heap_profiling() {
 }
 
-void enable_abort_on_allocation_failure() {
-    seastar_logger.warn("Seastar compiled with default allocator, will not abort on bad_alloc");
+void set_abort_on_allocation_failure(bool enabled) {
+    if (enabled) {
+        seastar_logger.warn("Seastar compiled with default allocator, will not abort on bad_alloc");
+    }
+}
 }
 
 reclaimer::reclaimer(std::function<reclaiming_result ()> reclaim, reclaimer_scope) {

--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1609,6 +1609,10 @@ void set_abort_on_allocation_failure(bool enabled) {
     abort_on_allocation_failure.store(enabled, std::memory_order_seq_cst);
 }
 
+bool is_abort_on_allocation_failure() {
+    return abort_on_allocation_failure;
+}
+
 void set_dump_memory_diagnostics_on_alloc_failure_kind(alloc_failure_kind kind) {
     dump_diagnostics_on_alloc_failure_kind.store(kind, std::memory_order_seq_cst);
 }
@@ -2260,6 +2264,9 @@ void set_abort_on_allocation_failure(bool enabled) {
         seastar_logger.warn("Seastar compiled with default allocator, will not abort on bad_alloc");
     }
 }
+
+bool is_abort_on_allocation_failure() {
+    return false;
 }
 
 reclaimer::reclaimer(std::function<reclaiming_result ()> reclaim, reclaimer_scope) {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -4007,7 +4007,7 @@ void smp::configure(const smp_options& smp_opts, const reactor_options& reactor_
     }
 
     if (reactor_opts.abort_on_seastar_bad_alloc) {
-        memory::enable_abort_on_allocation_failure();
+        memory::set_abort_on_allocation_failure(true);
     }
 
     if (reactor_opts.dump_memory_diagnostics_on_alloc_failure_kind) {

--- a/tests/unit/alloc_test.cc
+++ b/tests/unit/alloc_test.cc
@@ -198,6 +198,20 @@ SEASTAR_TEST_CASE(test_realloc_nullptr) {
     return make_ready_future<>();
 }
 
+SEASTAR_TEST_CASE(test_enable_abort_on_oom) {
+    bool original = seastar::memory::is_abort_on_allocation_failure();
+
+    seastar::memory::set_abort_on_allocation_failure(false);
+    BOOST_CHECK(!seastar::memory::is_abort_on_allocation_failure());
+
+    seastar::memory::set_abort_on_allocation_failure(true);
+    BOOST_CHECK(seastar::memory::is_abort_on_allocation_failure());
+
+    seastar::memory::set_abort_on_allocation_failure(original);
+
+    return make_ready_future<>();
+}
+
 SEASTAR_TEST_CASE(test_bad_alloc_throws) {
     // test that a large allocation throws bad_alloc
     auto stats = seastar::memory::stats();


### PR DESCRIPTION
We are moving to enable abort-on-OOM by default, and as part of this it is useful to be able to disable as well as enable this setting (current behavior is that it starts out disabled and the reactor does a one-time enable based on the command line flag --abort-on-seastar-bad-alloc.

This series implements the ability to disable it and also to get its status.

A small test is included.

There is a parallel PR for this same series on the scylladb side here:

https://github.com/scylladb/seastar/pull/1506

So we should give that a bit of time to see if there are changes there and realign in order to avoid merging issues later.