### PR TITLE
Dump memory diagnostics at error level on abort

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -1766,7 +1766,7 @@ seastar::internal::log_buf::inserter_iterator do_dump_memory_diagnostics(seastar
     return it;
 }
 
-void maybe_dump_memory_diagnostics(size_t size) {
+void maybe_dump_memory_diagnostics(size_t size, bool is_aborting) {
     if (report_on_alloc_failure_suppressed) {
         return;
     }
@@ -1791,6 +1791,11 @@ void maybe_dump_memory_diagnostics(size_t size) {
             break;
     }
 
+    if (is_aborting) {
+        // if we are about to abort, always report the memory diagnositics at error level
+        lvl = log_level::error;
+    }
+
     logger::lambda_log_writer writer([] (seastar::internal::log_buf::inserter_iterator it) {
         return do_dump_memory_diagnostics(it);
     });
@@ -1798,10 +1803,12 @@ void maybe_dump_memory_diagnostics(size_t size) {
 }
 
 void on_allocation_failure(size_t size) {
-    maybe_dump_memory_diagnostics(size);
+    bool will_abort = !abort_on_alloc_failure_suppressed
+            && abort_on_allocation_failure.load(std::memory_order_relaxed);
 
-    if (!abort_on_alloc_failure_suppressed
-            && abort_on_allocation_failure.load(std::memory_order_relaxed)) {
+    maybe_dump_memory_diagnostics(size, will_abort);
+
+    if (will_abort) {
         seastar_logger.error("Failed to allocate {} bytes", size);
         abort();
     }


### PR DESCRIPTION
When seastar is configured to throw on allocation failure, we have a bunch of rules which determine whether a memory diagnosis report is output, to avoid spamming the log in the case of repeated failures. In general this means that most allocation failures are logged at debug log level, with some "critical" failures being logged at error.

However, when --abort-on-seastar-bad-alloc is set, there will be at most one allocation failure in the lifetime of the process, after which will we abort so we'd *really* like the diagnosis to appear before we abort: essentially all allocation failures are "critical".

Enforce this by always logging at error log level when a failure occurs that will cause an abort.

cherry pick of:

scylladb/seastar 5ae1c60205bf52cc98a9819dd70001314069d280