### PR TITLE
optimize abort_source with default exn

### DIFF
--- a/include/seastar/core/abort_source.hh
+++ b/include/seastar/core/abort_source.hh
@@ -217,7 +217,8 @@ public:
     /// Returns the default exception type (\ref abort_requested_exception) for this abort source.
     /// Overridable by derived classes.
     virtual std::exception_ptr get_default_exception() const noexcept {
-        return make_exception_ptr(abort_requested_exception());
+        static const thread_local auto default_exception = make_exception_ptr(abort_requested_exception());
+        return default_exception;
     }
 };
 

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -60,6 +60,9 @@ macro (seastar_add_test name)
   set (${name}_test ${target})
 endmacro ()
 
+seastar_add_test (abort_source
+  SOURCES abort_source_perf.cc)
+
 seastar_add_test (fstream
   SOURCES fstream_perf.cc
   NO_SEASTAR_PERF_TESTING_LIBRARY)

--- a/tests/perf/abort_source_perf.cc
+++ b/tests/perf/abort_source_perf.cc
@@ -1,0 +1,42 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "seastar/core/abort_source.hh"
+#include "seastar/core/future.hh"
+#include <seastar/testing/perf_tests.hh>
+
+struct perf_abort_source {};
+
+PERF_TEST_F(perf_abort_source, abort_default_exception)
+{
+    constexpr size_t source_count = 10000;
+
+    std::vector<abort_source> as_vec;
+
+    for (size_t i = 0; i < source_count; ++i) {
+        as_vec.push_back(abort_source());
+    }
+
+    perf_tests::start_measuring_time();
+    for (auto& as : as_vec) {
+        as.request_abort();
+    }
+    perf_tests::stop_measuring_time();
+
+    return as_ready_future(source_count);
+}


### PR DESCRIPTION
When calling abort_source::request_abort() with a default exception, we can avoid the overhead of creating a new exception object. This is especially useful in performance-critical code where abort_source is used frequently.

To achieve this, we modify the request_abort() method to use a static exception object when the default exception is requested. This way, we can reuse the same exception object for all calls to request_abort().