### PR TITLE
Downstream Print incrementally in sigsegv handler

### DIFF
--- a/include/seastar/util/backtrace.hh
+++ b/include/seastar/util/backtrace.hh
@@ -60,16 +60,36 @@ bool operator==(const frame& a, const frame& b) noexcept;
 frame decorate(uintptr_t addr) noexcept;
 
 // Invokes func for each frame passing it as argument.
+// incremental=false is the default mode and simply calls ::backtrace once
+// and then calls func for each frame. If the ::backtrace call crashes,
+// func will not be called.
+// incremental=true will call ::backtrace in a loop, increasing the number of
+// frames to capture by one each time. This is useful for cases where
+// ::backtrace itself may crash, e.g., in a crash handler, in this case the
+// func will be called for each frame which didn't crash. See #2710. This
+// is much slower, however.
 SEASTAR_MODULE_EXPORT
 template<typename Func>
-void backtrace(Func&& func) noexcept(noexcept(func(frame()))) {
+void backtrace(Func&& func, bool incremental = false) noexcept(noexcept(func(frame()))) {
 #ifdef HAVE_EXECINFO
     constexpr size_t max_backtrace = 100;
     void* buffer[max_backtrace];
-    int n = ::backtrace(buffer, max_backtrace);
-    for (int i = 0; i < n; ++i) {
-        auto ip = reinterpret_cast<uintptr_t>(buffer[i]);
-        func(decorate(ip - 1));
+
+    if (incremental) {
+        for (size_t last_frame = 1; last_frame <= max_backtrace; ++last_frame) {
+            int n = ::backtrace(buffer, last_frame);
+            if (n < static_cast<int>(last_frame)) {
+                return;
+            }
+            auto ip = reinterpret_cast<uintptr_t>(buffer[last_frame-1]);
+            func(decorate(ip - 1));
+        }
+    } else {
+        int n = ::backtrace(buffer, max_backtrace);
+        for (int i = 0; i < n; ++i) {
+            auto ip = reinterpret_cast<uintptr_t>(buffer[i]);
+            func(decorate(ip - 1));
+        }
     }
 #else
 // Not implemented yet

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -789,13 +789,22 @@ class backtrace_buffer {
     static constexpr unsigned _max_size = 8 << 10;
     unsigned _pos = 0;
     char _buf[_max_size];
+    bool _immediate;
 public:
+    backtrace_buffer(bool immediate = false)
+        : _immediate{immediate} {}
+
     void flush() noexcept {
-        print_safe(_buf, _pos);
-        _pos = 0;
+        if (!_immediate) {
+            print_safe(_buf, _pos);
+            _pos = 0;
+        }
     }
 
     void reserve(size_t len) noexcept {
+        if (_immediate) {
+            return;
+        }
         SEASTAR_ASSERT(len < _max_size);
         if (_pos + len >= _max_size) {
             flush();
@@ -803,9 +812,13 @@ public:
     }
 
     void append(const char* str, size_t len) noexcept {
-        reserve(len);
-        memcpy(_buf + _pos, str, len);
-        _pos += len;
+        if (_immediate) {
+            print_safe(str, len);
+        } else {
+            reserve(len);
+            memcpy(_buf + _pos, str, len);
+            _pos += len;
+        }
     }
 
     void append(const char* str) noexcept { append(str, strlen(str)); }
@@ -835,7 +848,7 @@ public:
             append("0x");
             append_hex(f.addr);
             append("\n");
-        });
+        }, _immediate);
     }
 
     void append_backtrace_oneline() noexcept {
@@ -843,7 +856,7 @@ public:
             reserve(3 + sizeof(f.addr) * 2);
             append(" 0x");
             append_hex(f.addr);
-        });
+        }, _immediate);
     }
 };
 
@@ -867,8 +880,17 @@ static void print_with_backtrace(backtrace_buffer& buf, bool oneline) noexcept {
     buf.flush();
 }
 
-static void print_with_backtrace(const char* cause, bool oneline = false) noexcept {
-    backtrace_buffer buf;
+// Print the current backtrace to stdout with the given cause.
+// If oneline is true, backtrace is printed entirely on one line,
+// otherwise it is printed with 1 line per frame.
+// If immediate is true, the backtrace is printed frame by frame
+// with a call to write(2), otherwise it is printed in a single
+// call to write(2). The former strategy is more robust in cases
+// where the backtrace itself may crash at some point down the stack
+// while the latter is more efficient and avoids splitting output
+// in the face of concurrent logging by other shards.
+static void print_with_backtrace(const char* cause, bool oneline = false, bool immediate = false) noexcept {
+    backtrace_buffer buf(immediate);
     buf.append(cause);
     print_with_backtrace(buf, oneline);
 }
@@ -4161,7 +4183,9 @@ static void sigsegv_action(siginfo_t *info, ucontext_t* uc) noexcept {
     print_zero_padded_hex_safe(f.so->end - f.so->begin);
     print_safe("]\n");
 
-    print_with_backtrace("Segmentation fault");
+    // print the backtrace in immediate mode, so if we crash
+    // during the backtrace we get as much output as possible
+    print_with_backtrace("Segmentation fault", false, true);
     reraise_signal(SIGSEGV);
 }
 


### PR DESCRIPTION
A follow-up to https://github.com/redpanda-data/seastar/pull/200 to upstream: https://github.com/scylladb/seastar/pull/2712

This is necessary to be able to use the incremental `ss::backtrace` functionality in redpanda's signal handler.

This was intentionally skipped because it didn't backport cleanly, but I cherry-picked the change now and resolved the conflicts because this change needs to be backported to at least 25.1.

Fixes https://redpandadata.atlassian.net/browse/CORE-9899