### PR TITLE
State tracking v24.2.x

### DIFF
--- a/include/seastar/net/tls.hh
+++ b/include/seastar/net/tls.hh
@@ -635,6 +635,7 @@ namespace tls {
 
     const circular_buffer<sstring> & get_tls_log_buffer(connected_socket&);
     const tls_session_stats & get_tls_session_stats(connected_socket&);
+    sstring get_tls_state(connected_socket&);
 
     std::ostream& operator<<(std::ostream&, const subject_alt_name::value_type&);
     std::ostream& operator<<(std::ostream&, const subject_alt_name&);

--- a/src/net/tls-impl.cc
+++ b/src/net/tls-impl.cc
@@ -734,6 +734,10 @@ const tls::tls_session_stats& get_tls_session_stats(connected_socket& socket) {
     return get_tls_socket(socket)->get_tls_session_stats();
 }
 
+sstring get_tls_state(connected_socket& socket) {
+    return get_tls_socket(socket)->get_tls_state();
+}
+
 std::string_view tls::format_as(subject_alt_name_type type) {
     switch (type) {
         case subject_alt_name_type::dnsname:

--- a/src/net/tls-impl.hh
+++ b/src/net/tls-impl.hh
@@ -69,6 +69,7 @@ public:
     virtual future<session_data> get_session_resume_data() = 0;
     virtual const circular_buffer<sstring>& get_tls_log_buffer() const = 0;
     virtual const tls_session_stats& get_tls_session_stats() const = 0;
+    virtual sstring get_tls_state() const = 0;
 };
 
 struct session_ref {
@@ -162,6 +163,9 @@ public:
     }
     const tls_session_stats& get_tls_session_stats() const {
         return _session->get_tls_session_stats();
+    }
+    sstring get_tls_state() const {
+        return _session->get_tls_state();
     }
 };
 


### PR DESCRIPTION
This PR introduces a number of logging probes to the OpenSSL implementation in Seastar:

* Adds a new logger `seastar-tls`
  * Adds a number of log states, all at `debug` or at `trace`
  * All log messages are also stored in a circular buffer, maxing out at 256 entries
* Adds a new method `get_tls_log_buffer()` which can retrieve a reference to this log from the `connected_socket`
* Adds a number of new stats:
```c++
struct tls_session_stats {
        /// Raw number of bytes received off the wire
        size_t num_bytes_recv = 0;
        /// Raw number of bytes sent over the wire
        size_t num_bytes_sent = 0;
        /// Number of times handshake was requested
        size_t num_handshakes_requested = 0;
        /// Number of times handshake succeeded
        size_t num_handshakes_succeeded = 0;
        /// Number of times handshake failed
        size_t num_handshakes_failed = 0;
        /// Number of times, user requuested to 'put' data
        size_t num_puts_requested = 0;
        /// Number of times 'put' succeeded
        size_t num_puts_succeeded = 0;
        /// Number of times 'put' failed
        size_t num_puts_failed = 0;
        /// Number of times a user requested to 'get' data
        size_t num_gets_requested = 0;
        /// Number of times 'get' succeeded
        size_t num_gets_succeeded = 0;
        /// Number of times 'get'failed
        size_t num_gets_failed = 0;
        lowres_system_clock::time_point last_handshake_requested = lowres_system_clock::time_point::min();
        lowres_system_clock::time_point last_handshake_succeeded = lowres_system_clock::time_point::min();
        lowres_system_clock::time_point last_handshake_failed = lowres_system_clock::time_point::min();
        lowres_system_clock::time_point last_put_requested = lowres_system_clock::time_point::min();
        lowres_system_clock::time_point last_put_succeeded = lowres_system_clock::time_point::min();
        lowres_system_clock::time_point last_put_failed = lowres_system_clock::time_point::min();
        lowres_system_clock::time_point last_get_requested = lowres_system_clock::time_point::min();
        lowres_system_clock::time_point last_get_succeeded = lowres_system_clock::time_point::min();
        lowres_system_clock::time_point last_get_failed = lowres_system_clock::time_point::min();
    };
```
* These stats can be retrieved by the API call `get_tls_session_stats`
* Adds a `get_tls_state` method that returns a stringified version of the state and the rstate
* Adds an info callback that will log messages about changes state, see `ssl_info_callback`