### PR TITLE
io-queue: Use max cost function by default

### DIFF
--- a/include/seastar/core/io_queue.hh
+++ b/include/seastar/core/io_queue.hh
@@ -152,6 +152,7 @@ public:
         size_t write_bytes_rate = std::numeric_limits<size_t>::max();
         size_t read_req_rate = std::numeric_limits<size_t>::max();
         size_t write_req_rate = std::numeric_limits<size_t>::max();
+        bool max_cost_function = true;
     };
 
     io_queue(io_group_ptr group, internal::io_sink& sink);

--- a/src/core/io_queue.cc
+++ b/src/core/io_queue.cc
@@ -834,9 +834,14 @@ double internal::request_tokens(io_direction_and_length dnl, const io_queue::con
 
     const auto& m = mult[dnl.rw_idx()];
 
+    // See https://redpandadata.atlassian.net/wiki/x/CgAIGw#io-queue-cost-function
     double iops_cost = double(m.weight) / cfg.req_count_rate;
     double tp_cost = double(m.size) * (dnl.length() >> io_queue::block_size_shift) / cfg.blocks_count_rate;
-    return iops_cost + tp_cost;
+    if (cfg.max_cost_function) {
+        return std::max(iops_cost, tp_cost);
+    } else {
+        return iops_cost + tp_cost;
+    }
 }
 
 fair_queue_entry::capacity_t io_queue::request_capacity(io_direction_and_length dnl) const noexcept {

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -205,6 +205,7 @@ struct disk_params {
     uint64_t write_saturation_length = std::numeric_limits<uint64_t>::max();
     bool duplex = false;
     float rate_factor = 1.0;
+    bool max_cost_function = true;
 };
 
 }
@@ -234,6 +235,9 @@ struct convert<seastar::disk_params> {
         }
         if (node["rate_factor"]) {
             mp.rate_factor = node["rate_factor"].as<float>();
+        }
+        if (node["max_cost_function"]) {
+            mp.max_cost_function = node["max_cost_function"].as<bool>();
         }
         return true;
     }
@@ -4407,6 +4411,7 @@ public:
         cfg.write_bytes_rate = p.write_bytes_rate;
         cfg.read_req_rate = p.read_req_rate;
         cfg.write_req_rate = p.write_req_rate;
+        cfg.max_cost_function = p.max_cost_function;
 
         return cfg;
     }


### PR DESCRIPTION
Switch the io-queue cost function over to use max(IOPS cost, TP cost)
away from sum(IOPS cost, TP cost).

In its form today the io-queue fails to reach the advertised
throughput/IOPS numbers from io-properties (see
[seastar#2771](https://github.com/scylladb/seastar/issues/2771) for
details).

The reason for this is easy to understand when looking at a disk like the
ones from the m7gd AWS series. They (approximately) achieve full throughput as
well as full IOPS at 4k IOP size.

This means that for cost modelling for a single IO operation it would be
enough to just look at one dimension, either throughput or IOPS but not
both. The current cost function which is always additive in IOP and throughput
cost however costs operation way too high. This leads to the aforementioned
problem where the io-queue underperforms. Taking 4k IOPS on
m7gd as an example we only get around 60% of the disk performance.

From various testing the max cost function seems to model disks better
than the sum cost function and avoids the problem mentioned above. Note
this doesn't change the "outer" cost model of how the costs of
individual operations are summed together. That also isn't modelled
entirely right for more modern disks but is pessimistically fine and not
the focus of this patch.

The problem can be easily shown using the following io-tester config:

```
- name: highprio
  shards: [0]
  type: randwrite
  shard_info:
    parallelism: 32
    reqsize: 4kB|16kB|128kB
    shares: 1000
    think_time: 0

- name: lowprio
  shards: [0]
  type: randwrite
  shard_info:
    parallelism: 32
    reqsize: 4kB|16kB|128kB
    shares: 100
    think_time: 0
```

On m7gd.4xl (all numbers in MB/s):
 - NOIP: Not using io-properties
 - IP: Using io-properties
 - MCF: Using io-properties with the max cost function

<table>
  <thead>
    <tr>
      <th rowspan="2"></th>
      <th colspan="3">4k</th>
      <th colspan="3">16k</th>
      <th colspan="3">128k</th>
    </tr>
    <tr>
      <th>high prio</th>
      <th>low prio</th>
      <th>total</th>
      <th>high prio</th>
      <th>low prio</th>
      <th>total</th>
      <th>high prio</th>
      <th>low prio</th>
      <th>total</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>NOIP</td>
      <td>303</td>
      <td>287</td>
      <td>591</td>
      <td>299</td>
      <td>292</td>
      <td>591</td>
      <td>295</td>
      <td>295</td>
      <td>590</td>
    </tr>
    <tr>
      <td>IP</td>
      <td>262</td>
      <td>28</td>
      <td>290</td>
      <td>432</td>
      <td>44</td>
      <td>476</td>
      <td>528</td>
      <td>53</td>
      <td>581</td>
    </tr>
    <tr>
      <td>MCF</td>
      <td>476</td>
      <td>56</td>
      <td>532</td>
      <td>543</td>
      <td>55</td>
      <td>598</td>
      <td>544</td>
      <td>55</td>
      <td>599</td>
    </tr>
  </tbody>
</table>


We see that at low IOP size using no io-properties we do get the full
throughput but no scheduling (bad), using io-properties we do get scheduling
but low throughput and with the max cost function we get both.

More data and extensive discussion can be found here:

 - https://github.com/scylladb/seastar/pull/2801#issuecomment-3070114487
 - https://github.com/scylladb/seastar/issues/2840#issuecomment-3070100437
 - https://docs.google.com/spreadsheets/d/1u_9tRxePkq-OYFiba8xz4JY54P2VJ-JQBvhuBv04tmo

These tests also include latency tests in priority scenarios and
different kind of disks like EBS. The linked PR also includes a
discussion about a different approach using a weighted cost function.

Note that in general latency is often a function of throughput as the
io-queue arbitrarily keeping things in the queue induces latency. This
is especially true for real world usecases like RP where write
amplification is generally fairly high but at the same time can be
absorbed at the cost of latency.