### PR TITLE
Downstream perf_test hooks

### DIFF
--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -393,6 +393,19 @@ public:
 
 };
 
+static std::vector<pre_run_hook> pre_run_hooks;
+
+int register_pre_run_hook(pre_run_hook hook) {
+    pre_run_hooks.emplace_back(std::move(hook));
+    return 0; // this return value just helps run this function as a global constructor
+}
+
+void performance_test::run_hooks() {
+    for (auto& hook : pre_run_hooks) {
+        hook(test_group(), test_case());
+    }
+}
+
 void performance_test::do_run(const config& conf)
 {
     _max_single_run_iterations = conf.single_run_iterations;

--- a/tests/perf/perf_tests_perf.cc
+++ b/tests/perf/perf_tests_perf.cc
@@ -66,3 +66,33 @@ PERF_TEST_CN(fixture, test_coro_n) {
     co_await coroutine::maybe_yield();
     co_return loop();
 }
+
+PERF_TEST(perf_tests, test_empty) { }
+
+PERF_TEST(perf_tests, test_timer_overhead) {
+    constexpr auto TIMER_LOOPS = 1000;
+    for (size_t i = 0; i < TIMER_LOOPS; i++) {
+        perf_tests::start_measuring_time();
+        perf_tests::stop_measuring_time();
+    }
+    return TIMER_LOOPS;
+}
+
+// The following tests run in order check that pre-run hooks are executed properly.
+
+static int hook_1_count = 0, hook_2_count = 1;
+
+PERF_PRE_RUN_HOOK([](const std::string& g, const std::string& c) {
+    ++hook_1_count;
+});
+
+PERF_PRE_RUN_HOOK([](const std::string& g, const std::string& c) {
+    ++hook_2_count;
+});
+
+PERF_TEST(hook_checker, hook_did_run_0) {
+    // check in a subsequent test that the hook ran
+    assert(hook_1_count > 0);
+    assert(hook_2_count > 0);
+}
+


### PR DESCRIPTION
This pull request introduces a new mechanism for registering and executing pre-run hooks in the Seastar performance testing framework. The main goal is to allow custom functions to be invoked before each test run, improving extensibility and enabling additional setup or instrumentation. The changes include the definition and registration of pre-run hooks, their integration into the test execution flow, and new tests to verify hook behavior.

### Pre-run hook infrastructure

* Added the `pre_run_hook` type using `noncopyable_function<void(const sstring&, const sstring&)>` to represent hooks that run before each test.
* Implemented a global registry (`pre_run_hooks`) and a registration function (`register_pre_run_hook`) to manage pre-run hooks, along with the `PERF_PRE_RUN_HOOK` macro for easy hook registration. [[1]](diffhunk://#diff-dabffe0cb7dcf52e9324ce05054be3244a5844578c8723cbb2838a0d0da05ffeR303-R306) [[2]](diffhunk://#diff-dabffe0cb7dcf52e9324ce05054be3244a5844578c8723cbb2838a0d0da05ffeR374-R389) [[3]](diffhunk://#diff-d476a7e19fc219a468a4cf5b27a5025797cc207ca5f73b5b922c8210121ef635R396-R408)

### Integration into test execution

* Modified the `performance_test` class to invoke all registered pre-run hooks at the start of each test run via the new `run_hooks()` method, which is called in `do_single_run()`. [[1]](diffhunk://#diff-dabffe0cb7dcf52e9324ce05054be3244a5844578c8723cbb2838a0d0da05ffeR150-R152) [[2]](diffhunk://#diff-dabffe0cb7dcf52e9324ce05054be3244a5844578c8723cbb2838a0d0da05ffeR257) [[3]](diffhunk://#diff-d476a7e19fc219a468a4cf5b27a5025797cc207ca5f73b5b922c8210121ef635R396-R408)

### New and updated tests

* Added new performance tests (`test_empty`, `test_timer_overhead`) and tests to verify that pre-run hooks are executed correctly (`hook_did_run_0`).