### PR TITLE
GHA: increase timeout to 60 minutes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 40
+    timeout-minutes: 60
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Increase the "test" task timeout to 60 minutes as it is failing reliably at 40 minutes on the DPDK subrun.