### PR TITLE
tls/ossl: Handle remote endpoint closing before TLS session created

### DIFF
--- a/include/seastar/net/stack.hh
+++ b/include/seastar/net/stack.hh
@@ -46,8 +46,8 @@ public:
     virtual keepalive_params get_keepalive_parameters() const = 0;
     virtual void set_sockopt(int level, int optname, const void* data, size_t len) = 0;
     virtual int get_sockopt(int level, int optname, void* data, size_t len) const = 0;
-    virtual socket_address local_address() const noexcept = 0;
-    virtual socket_address remote_address() const noexcept = 0;
+    virtual socket_address local_address() const = 0;
+    virtual socket_address remote_address() const = 0;
     virtual future<> wait_input_shutdown() = 0;
 };
 

--- a/src/net/native-stack-impl.hh
+++ b/src/net/native-stack-impl.hh
@@ -117,8 +117,8 @@ public:
     keepalive_params get_keepalive_parameters() const override;
     int get_sockopt(int level, int optname, void* data, size_t len) const override;
     void set_sockopt(int level, int optname, const void* data, size_t len) override;
-    socket_address local_address() const noexcept override;
-    socket_address remote_address() const noexcept override;
+    socket_address local_address() const override;
+    socket_address remote_address() const override;
     virtual future<> wait_input_shutdown() override;
 };
 
@@ -290,12 +290,12 @@ int native_connected_socket_impl<Protocol>::get_sockopt(int level, int optname, 
 }
 
 template<typename Protocol>
-socket_address native_connected_socket_impl<Protocol>::local_address() const noexcept {
+socket_address native_connected_socket_impl<Protocol>::local_address() const {
     return {_conn->local_ip(), _conn->local_port()};
 }
 
 template<typename Protocol>
-socket_address native_connected_socket_impl<Protocol>::remote_address() const noexcept {
+socket_address native_connected_socket_impl<Protocol>::remote_address() const {
     return {_conn->foreign_ip(), _conn->foreign_port()};
 }
 

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -285,10 +285,10 @@ public:
     int get_sockopt(int level, int optname, void* data, size_t len) const override {
         return _ops->get_sockopt(_fd.get_file_desc(), level, optname, data, len);
     }
-    socket_address local_address() const noexcept override {
+    socket_address local_address() const override {
         return _ops->local_address(_fd.get_file_desc());
     }
-    socket_address remote_address() const noexcept override {
+    socket_address remote_address() const override {
         return _ops->remote_address(_fd.get_file_desc());
     }
     future<> wait_input_shutdown() override {


### PR DESCRIPTION
There exists a remote possibility that before the client connection is wrapped in a TLS session, that the remote endpoint has closed the connection with the client.  When that occurs, the call to `getpeername` will fail.  The socket method `remote_address` was marked `noexcept` and this would have resulted in an abort when this occurs.  The `noexcept` has been removed and the session constructor will not handle an exception from `connected_socket::remote_address()` and return a default value.

Fixes: CORE-14504