### PR TITLE
OSSL null dereference fix and safety

### DIFF
--- a/include/seastar/net/packet.hh
+++ b/include/seastar/net/packet.hh
@@ -316,6 +316,11 @@ public:
     static packet make_null_packet() noexcept {
         return net::packet(nullptr);
     }
+
+    bool is_null_packet() const noexcept {
+        return _impl == nullptr;
+    }
+    
 private:
     void linearize(size_t at_frag, size_t desired_size);
     bool allocate_headroom(size_t size);

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -411,7 +411,9 @@ future<> pollable_fd_state::write_all(const uint8_t* buffer, size_t size) {
 }
 
 future<> pollable_fd_state::write_all(net::packet& p) {
+    SEASTAR_ASSERT(!p.is_null_packet());
     return write_some(p).then([this, &p] (size_t size) {
+        SEASTAR_ASSERT(!p.is_null_packet());
         if (p.len() == size) {
             return make_ready_future<>();
         }


### PR DESCRIPTION
https://redpandadata.atlassian.net/browse/CORE-14423

OSSL uses ongoing_put's completion as a fence to prevent multiple puts from being executed on a socket at a given time.

wait_for_output, though, consumes ongoing_put, thus opening a window between the moment of consumption to the completion of the extracted future, in which another put can inappropriately be put on the same socket.

These two puts will race, and completion of one can yield a null reference to the other.

This PR adds 1. safety around this race and 2. some asserts to transmute undefined behavior to a well defined node crash