### PR TITLE
Revert reactor asserts (bad perf) in exchange for cheaper put assert

### DIFF
--- a/include/seastar/net/packet.hh
+++ b/include/seastar/net/packet.hh
@@ -316,11 +316,6 @@ public:
     static packet make_null_packet() noexcept {
         return net::packet(nullptr);
     }
-
-    bool is_null_packet() const noexcept {
-        return _impl == nullptr;
-    }
-    
 private:
     void linearize(size_t at_frag, size_t desired_size);
     bool allocate_headroom(size_t size);

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -125,7 +125,7 @@ public:
 
 class posix_data_sink_impl : public data_sink_impl {
     pollable_fd _fd;
-    packet _p;
+    packet _p{net::packet::make_null_packet()};
 public:
     explicit posix_data_sink_impl(pollable_fd fd) : _fd(std::move(fd)) {}
     using data_sink_impl::put;

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -411,9 +411,7 @@ future<> pollable_fd_state::write_all(const uint8_t* buffer, size_t size) {
 }
 
 future<> pollable_fd_state::write_all(net::packet& p) {
-    SEASTAR_ASSERT(!p.is_null_packet());
     return write_some(p).then([this, &p] (size_t size) {
-        SEASTAR_ASSERT(!p.is_null_packet());
         if (p.len() == size) {
             return make_ready_future<>();
         }

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -683,6 +683,7 @@ posix_data_sink_impl::put(temporary_buffer<char> buf) {
 
 future<>
 posix_data_sink_impl::put(packet p) {
+    SEASTAR_ASSERT(!_p);
     _p = std::move(p);
     auto sg_id = internal::scheduling_group_index(current_scheduling_group());
     bytes_sent[sg_id] += _p.len();


### PR DESCRIPTION
We observed a null pointer dereference in a test involving ossl which appeared to be because there were two in-flight puts onto a socket attached iostream.

Previously, we placed asserts at the call site where the null dereference occurred but this is too expensive for our perf tests.

The next best thing is to place asserts at the suspected on-ramp to where the null dereference occured.

This pr reverts the prior asserts and exchanges them for cheaper asserts