### PR TITLE
Revert "posix-stack: add assert to put(packet)"

### DIFF
--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -125,7 +125,7 @@ public:
 
 class posix_data_sink_impl : public data_sink_impl {
     pollable_fd _fd;
-    packet _p{net::packet::make_null_packet()};
+    packet _p;
 public:
     explicit posix_data_sink_impl(pollable_fd fd) : _fd(std::move(fd)) {}
     using data_sink_impl::put;

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -683,7 +683,6 @@ posix_data_sink_impl::put(temporary_buffer<char> buf) {
 
 future<>
 posix_data_sink_impl::put(packet p) {
-    SEASTAR_ASSERT(!_p);
     _p = std::move(p);
     auto sg_id = internal::scheduling_group_index(current_scheduling_group());
     bytes_sent[sg_id] += _p.len();


### PR DESCRIPTION
This assert was added to guard against multiple talkers on the same socket-bound output stream in ossl.

This assert is hitting, but not in ossl, see the below build.

https://buildkite.com/redpanda/redpanda/builds/76335#019a83bf-ac64-48a9-8520-388126d7d7f6

Reverting this assert for the time being and cutting a ticket on above failure