### PR TITLE
packet.hh: add assert on len()

### DIFF
--- a/include/seastar/net/packet.hh
+++ b/include/seastar/net/packet.hh
@@ -237,7 +237,10 @@ public:
         return *this;
     }
 
-    unsigned len() const noexcept { return _impl->_len; }
+    unsigned len() const noexcept {
+        SEASTAR_ASSERT(_impl);
+        return _impl->_len;
+    }
     unsigned memory() const noexcept { return len() +  sizeof(packet::impl); }
 
     fragment frag(unsigned idx) const noexcept { return _impl->_frags[idx]; }


### PR DESCRIPTION
An assert which checks the validity of _impl before calling into it.

This assert is meant to rotate previously seen undefined behavior into a node crash.