### PR TITLE
posix-stack: add null check

### DIFF
--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -125,7 +125,7 @@ public:
 
 class posix_data_sink_impl : public data_sink_impl {
     pollable_fd _fd;
-    packet _p;
+    packet _p{net::packet::make_null_packet()};
 public:
     explicit posix_data_sink_impl(pollable_fd fd) : _fd(std::move(fd)) {}
     using data_sink_impl::put;

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -683,10 +683,11 @@ posix_data_sink_impl::put(temporary_buffer<char> buf) {
 
 future<>
 posix_data_sink_impl::put(packet p) {
+    SEASTAR_ASSERT(!_p);
     _p = std::move(p);
     auto sg_id = internal::scheduling_group_index(current_scheduling_group());
     bytes_sent[sg_id] += _p.len();
-    return _fd.write_all(_p).then([this] { _p.reset(); });
+    return _fd.write_all(_p).finally([this] { _p.reset(); });
 }
 
 future<>


### PR DESCRIPTION
Adds assert to the on-ramps to net::packet UB.
This commit changes posix_data_sink_impl to guard against concurrency problems by asserting that its contained net::packet is null before accepting another.

changes:
net_packet now initialized as a null packet instead of a default packet added assert to put(net::packet) that checks the contained packet is null
write_all can throw, change the packet reset to occur regardless of exceptions