### PR TITLE
Back-port packet assert from v26.1.x

### DIFF
--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -125,7 +125,7 @@ public:
 
 class posix_data_sink_impl : public data_sink_impl {
     pollable_fd _fd;
-    packet _p;
+    packet _p{net::packet::make_null_packet()};
 public:
     explicit posix_data_sink_impl(pollable_fd fd) : _fd(std::move(fd)) {}
     using data_sink_impl::put;

--- a/src/net/posix-stack.cc
+++ b/src/net/posix-stack.cc
@@ -683,10 +683,11 @@ posix_data_sink_impl::put(temporary_buffer<char> buf) {
 
 future<>
 posix_data_sink_impl::put(packet p) {
+    SEASTAR_ASSERT(!_p);
     _p = std::move(p);
     auto sg_id = internal::scheduling_group_index(current_scheduling_group());
     bytes_sent[sg_id] += _p.len();
-    return _fd.write_all(_p).then([this] { _p.reset(); });
+    return _fd.write_all(_p).finally([this] { _p.reset(); });
 }
 
 future<>


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/seastar/commit/a74d64f625c19a76f5ec0ad8cac96eb00a667136
With the modifications for the future api version cut out.

This assert has baked long enough to be reasonable to backport