### PR TITLE
change where newline is emitted

### DIFF
--- a/src/core/prometheus.cc
+++ b/src/core/prometheus.cc
@@ -828,8 +828,9 @@ metric_family_range get_range(const metrics_families_per_shard& mf, const sstrin
 template <typename Extra = no_label>
 static inline void write_series(buf_t& buf, std::string_view name, const labels_type& labels, const config& ctx, auto v, std::string_view suffix, Extra e = {}) {
     write_name_and_labels(buf, name, suffix, labels, ctx, e);
-    static constexpr auto format = std::is_floating_point_v<decltype(v)> ? "{:g}\n" : "{}\n";
+    static constexpr auto format = std::is_floating_point_v<decltype(v)> ? "{:g}" : "{}";
     fmt::format_to(buf.back_insert_begin(), FMT_COMPILE(format), v);
+    buf << "\n";
 };
 
 


### PR DESCRIPTION
We are seeing odd metric corruption in some benchmark runs.

There is an outside chance is is related to fmt format_to which prints the floating point value and newline at the end of the line. To help diagnose this, print the newline separately, since if that's the problem the garbage will move from the beginning to the end of the line.