### PR TITLE
Estimate timing overhead, allow failing if it is too high

### DIFF
--- a/include/seastar/testing/perf_tests.hh
+++ b/include/seastar/testing/perf_tests.hh
@@ -129,6 +129,7 @@ public:
     struct run_result {
         clock_type::duration duration;
         perf_stats stats;
+        uint64_t start_stop_count = 0;
     };
 protected:
     [[gnu::always_inline]] [[gnu::hot]]

--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -56,6 +56,8 @@ template <> struct fmt::formatter<perf_tests::internal::duration> : fmt::ostream
 namespace perf_tests {
 namespace internal {
 
+using namespace std::chrono_literals;
+
 namespace {
 
 // We need to use signal-based timer instead of seastar ones so that
@@ -148,6 +150,12 @@ class time_measurement {
     linux_perf_event _instructions_retired_counter = linux_perf_event::user_instructions_retired();
     linux_perf_event _cpu_cycles_retired_counter = linux_perf_event::user_cpu_cycles_retired();
 
+    uint64_t _start_stop_count = 0;
+
+    // Calibrated cost of a single start_measuring_time()/stop_measuring_time() pair
+    clock_type::duration _start_stop_overhead{0};         // internal timing (used for overhead calculations)
+    clock_type::duration _start_stop_overhead_external{0}; // external clock measurement (for comparison)
+
 public:
     void enable_counters() {
         _instructions_retired_counter.enable();
@@ -162,6 +170,7 @@ public:
     void start_run() {
         _total_time = { };
         _total_stats = {};
+        _start_stop_count = 1;  // Start at 1 because we start timing here
         auto t = clock_type::now();
         _run_start_time = t;
         _start_time = t;
@@ -179,10 +188,12 @@ public:
             ret.duration = _total_time;
             ret.stats = _total_stats;
         }
+        ret.start_stop_count = _start_stop_count;
         return ret;
     }
 
     void start_iteration() {
+        ++_start_stop_count;
         _start_time = clock_type::now();
         _start_stats = perf_stats::snapshot(&_instructions_retired_counter, &_cpu_cycles_retired_counter);
     }
@@ -193,6 +204,41 @@ public:
         perf_stats stats;
         stats = perf_stats::snapshot(&_instructions_retired_counter, &_cpu_cycles_retired_counter);
         _total_stats += stats - _start_stats;
+    }
+
+    clock_type::duration start_stop_overhead() const { return _start_stop_overhead; }
+    clock_type::duration start_stop_overhead_external() const { return _start_stop_overhead_external; }
+
+    void calibrate_overhead() {
+        constexpr int CALIBRATION_LOOPS = 1000;
+
+        // Warm up
+        for (int i = 0; i < 100; i++) {
+            start_iteration();
+            stop_iteration();
+        }
+
+        // Use internal timing via start_run/stop_run (same as real tests)
+        enable_counters();
+        start_run();
+        for (int i = 0; i < CALIBRATION_LOOPS; i++) {
+            start_iteration();
+            stop_iteration();
+        }
+        auto result = stop_run();
+        disable_counters();
+
+        _start_stop_overhead = result.duration / CALIBRATION_LOOPS;
+
+        // Also measure with external clock for comparison
+        auto start = clock_type::now();
+        for (int i = 0; i < CALIBRATION_LOOPS; i++) {
+            start_iteration();
+            stop_iteration();
+        }
+        auto end = clock_type::now();
+
+        _start_stop_overhead_external = (end - start) / CALIBRATION_LOOPS;
     }
 };
 
@@ -244,6 +290,8 @@ struct config {
     unsigned number_of_runs;
     std::vector<std::unique_ptr<result_printer>> printers;
     unsigned random_seed = 0;
+    double overhead_threshold = 0.1;  // warn if overhead exceeds this ratio (e.g., 0.1 = 10%)
+    bool fail_on_high_overhead = false;  // fail the test run if overhead exceeds threshold
 };
 
 // absorbs a single metric across all runs and calculates summary statistics
@@ -294,7 +342,8 @@ struct result {
         allocs{run_count},
         tasks{run_count},
         inst{run_count},
-        cycles{run_count}
+        cycles{run_count},
+        overhead{run_count}
         {}
 
     sstring test_name = "";
@@ -308,10 +357,17 @@ struct result {
     float_stats<> tasks;
     float_stats<> inst;
     float_stats<> cycles;
+    float_stats<> overhead;  // overhead percentage from start/stop timing calls
 };
 
-struct duration {
-    double value;
+struct duration { 
+    double value;  // in nanoseconds
+
+    constexpr explicit duration(double nanos = 0) : value(nanos) {}
+
+    template <typename Rep, typename Period>
+    constexpr explicit duration(std::chrono::duration<Rep, Period> d)
+        : value(d / 1ns) {}
 };
 
 struct scaled_duration {
@@ -557,10 +613,11 @@ struct column {
 using columns = std::vector<column>;
 
 static const std::vector<column> common_columns{
-    {"allocs", 3, [](const result& r) { return r.allocs;              }},
-    {"tasks" , 3, [](const result& r) { return r.tasks;               }},
-    {"inst"  , 2, [](const result& r) { return r.inst;                }},
-    {"cycles", 1, [](const result& r) { return r.cycles;              }},
+    {"allocs"  ,  3, [](const result& r) { return r.allocs;              }},
+    {"tasks"   ,  3, [](const result& r) { return r.tasks;               }},
+    {"inst"    ,  2, [](const result& r) { return r.inst;                }},
+    {"cycles"  ,  1, [](const result& r) { return r.cycles;              }},
+    {"overhead",  1, [](const result& r) { return r.overhead;            }},
 };
 // json columns
 static const std::vector<column> json_columns = [] {
@@ -635,12 +692,14 @@ struct stdout_printer : text_printer {
         : text_printer(columns, options) {}
 
     virtual void print_configuration(const config& c) override {
-        fmt::print("{:<25} {}\n{:<25} {}\n{:<25} {}\n{:<25} {}\n{:<25} {}\n\n",
+        fmt::print("{:<25} {}\n{:<25} {}\n{:<25} {}\n{:<25} {}\n{:<25} {}\n{:<25} {} ({})\n\n",
                 "single run iterations:", c.single_run_iterations,
                 "single run duration:", duration { double(c.single_run_duration.count()) },
                 "number of runs:", c.number_of_runs,
                 "number of cores:", smp::count,
-                "random seed:", c.random_seed);
+                "random seed:", c.random_seed,
+                "start/stop overhead:", duration { measure_time.start_stop_overhead() },
+                duration { measure_time.start_stop_overhead_external() });
 
         print_header_row();
     }
@@ -759,6 +818,11 @@ void performance_test::do_run(const config& conf)
                 add(r.tasks, rr.stats.tasks_executed);
                 add(r.inst, rr.stats.instructions_retired);
                 add(r.cycles, rr.stats.cpu_cycles_retired);
+
+                // Calculate overhead ratio from start/stop timing calls
+                auto overhead = rr.start_stop_count * measure_time.start_stop_overhead();
+                double overhead_ratio = dt.count() ? (1.0 * overhead / dt) : 0.;
+                r.overhead.add(overhead_ratio, 1.0);  // already per-run, not per-iteration
             });
         }).get();
     }
@@ -769,6 +833,18 @@ void performance_test::do_run(const config& conf)
 
     for (auto& rp : conf.printers) {
         rp->print_result(r);
+    }
+
+    // Check if overhead exceeds threshold and warn/fail
+    double median_overhead = r.overhead.stats().med;
+    if (median_overhead > conf.overhead_threshold) {
+        fmt::print("WARNING: test '{}' has high measurement overhead: {:.1f}% (threshold: {:.1f}%)\n",
+                   name(), median_overhead * 100, conf.overhead_threshold * 100);
+        if (conf.fail_on_high_overhead) {
+            throw std::runtime_error(fmt::format(
+                "Test '{}' failed due to high measurement overhead: {:.1f}%",
+                name(), median_overhead * 100));
+        }
     }
 }
 
@@ -819,7 +895,9 @@ void run_all(const std::vector<std::string>& test_patterns, config& conf) {
         rp->print_configuration(conf);
     }
     for (auto& t : all_tests()) {
-        if (match(t.get())) { t->run(conf); }
+        if (match(t.get())) {
+            t->run(conf);
+        }
     }
 }
 
@@ -849,11 +927,15 @@ int main(int ac, char** av)
         ("columns", bpo::value<std::string>()->default_value("all"),
             "comma separated list of column (by name) to include in text/md output, or 'all'")
         ("list", "list available tests")
+        ("overhead-threshold", bpo::value<double>()->default_value(0.1),
+            "warn if overhead exceeds this ratio (default: 0.1 = 10%)")
+        ("fail-on-high-overhead", "fail the test run if any test exceeds the overhead threshold")
         ;
 
     return app.run(ac, av, [&] {
         return async([&] {
             signal_timer::init();
+            measure_time.calibrate_overhead();
 
             config conf;
             conf.single_run_iterations = app.configuration()["iterations"].as<size_t>();
@@ -861,6 +943,8 @@ int main(int ac, char** av)
             conf.single_run_duration = std::chrono::duration_cast<std::chrono::nanoseconds>(dur);
             conf.number_of_runs = app.configuration()["runs"].as<size_t>();
             conf.random_seed = app.configuration()["random-seed"].as<unsigned>();
+            conf.overhead_threshold = app.configuration()["overhead-threshold"].as<double>();
+            conf.fail_on_high_overhead = app.configuration().count("fail-on-high-overhead") > 0;
 
             std::vector<std::string> tests_to_run;
             if (app.configuration().count("test")) {

--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -159,7 +159,6 @@ public:
         _cpu_cycles_retired_counter.disable();
     }
 
-    [[gnu::always_inline]] [[gnu::hot]]
     void start_run() {
         _total_time = { };
         _total_stats = {};
@@ -169,7 +168,6 @@ public:
         _start_stats = perf_stats::snapshot(&_instructions_retired_counter, &_cpu_cycles_retired_counter);
     }
 
-    [[gnu::always_inline]] [[gnu::hot]]
     performance_test::run_result stop_run() {
         auto t = clock_type::now();
         performance_test::run_result ret;
@@ -184,13 +182,11 @@ public:
         return ret;
     }
 
-    [[gnu::always_inline]] [[gnu::hot]]
     void start_iteration() {
         _start_time = clock_type::now();
         _start_stats = perf_stats::snapshot(&_instructions_retired_counter, &_cpu_cycles_retired_counter);
     }
 
-    [[gnu::always_inline]] [[gnu::hot]]
     void stop_iteration() {
         auto t = clock_type::now();
         _total_time += t - _start_time;

--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -137,16 +137,88 @@ perf_stats perf_stats::snapshot(linux_perf_event* instructions_retired_counter, 
     );
 }
 
-time_measurement measure_time;
+class time_measurement {
+    clock_type::time_point _run_start_time;
+    clock_type::time_point _start_time;
+    clock_type::duration _total_time;
 
-void time_measurement::enable_counters() {
-    _instructions_retired_counter.enable();
-    _cpu_cycles_retired_counter.enable();
+    perf_stats _start_stats;
+    perf_stats _total_stats;
+
+    linux_perf_event _instructions_retired_counter = linux_perf_event::user_instructions_retired();
+    linux_perf_event _cpu_cycles_retired_counter = linux_perf_event::user_cpu_cycles_retired();
+
+public:
+    void enable_counters() {
+        _instructions_retired_counter.enable();
+        _cpu_cycles_retired_counter.enable();
+    }
+
+    void disable_counters() {
+        _instructions_retired_counter.disable();
+        _cpu_cycles_retired_counter.disable();
+    }
+
+    [[gnu::always_inline]] [[gnu::hot]]
+    void start_run() {
+        _total_time = { };
+        _total_stats = {};
+        auto t = clock_type::now();
+        _run_start_time = t;
+        _start_time = t;
+        _start_stats = perf_stats::snapshot(&_instructions_retired_counter, &_cpu_cycles_retired_counter);
+    }
+
+    [[gnu::always_inline]] [[gnu::hot]]
+    performance_test::run_result stop_run() {
+        auto t = clock_type::now();
+        performance_test::run_result ret;
+        if (_start_time == _run_start_time) {
+            ret.duration = t - _start_time;
+            auto stats = perf_stats::snapshot(&_instructions_retired_counter, &_cpu_cycles_retired_counter);
+            ret.stats = stats - _start_stats;
+        } else {
+            ret.duration = _total_time;
+            ret.stats = _total_stats;
+        }
+        return ret;
+    }
+
+    [[gnu::always_inline]] [[gnu::hot]]
+    void start_iteration() {
+        _start_time = clock_type::now();
+        _start_stats = perf_stats::snapshot(&_instructions_retired_counter, &_cpu_cycles_retired_counter);
+    }
+
+    [[gnu::always_inline]] [[gnu::hot]]
+    void stop_iteration() {
+        auto t = clock_type::now();
+        _total_time += t - _start_time;
+        perf_stats stats;
+        stats = perf_stats::snapshot(&_instructions_retired_counter, &_cpu_cycles_retired_counter);
+        _total_stats += stats - _start_stats;
+    }
+};
+
+static time_measurement measure_time;
+
+void performance_test::start_run() {
+    measure_time.enable_counters();
+    measure_time.start_run();
 }
 
-void time_measurement::disable_counters() {
-    _instructions_retired_counter.disable();
-    _cpu_cycles_retired_counter.disable();
+performance_test::run_result performance_test::stop_run() {
+    auto ret = measure_time.stop_run();
+    measure_time.disable_counters();
+    return ret;
+}
+
+void time_measurement_start_iteration() {
+    measure_time.start_iteration();
+}
+
+void time_measurement_stop_iteration() {
+    measure_time.stop_iteration();
 }
 
 struct config;

--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -139,6 +139,16 @@ perf_stats perf_stats::snapshot(linux_perf_event* instructions_retired_counter, 
 
 time_measurement measure_time;
 
+void time_measurement::enable_counters() {
+    _instructions_retired_counter.enable();
+    _cpu_cycles_retired_counter.enable();
+}
+
+void time_measurement::disable_counters() {
+    _instructions_retired_counter.disable();
+    _cpu_cycles_retired_counter.disable();
+}
+
 struct config;
 struct result;
 

--- a/tests/perf/perf_tests_perf.cc
+++ b/tests/perf/perf_tests_perf.cc
@@ -123,6 +123,18 @@ PERF_TEST(perf_tests, test_timer_overhead) {
     return TIMER_LOOPS;
 }
 
+// Test to verify overhead measurement - this test intentionally has high overhead
+// because it does almost no work between start/stop calls
+PERF_TEST(overhead_check, high_overhead_test) {
+    constexpr size_t LOOPS = 1000;
+    for (size_t i = 0; i < LOOPS; i++) {
+        perf_tests::start_measuring_time();
+        perf_tests::do_not_optimize(i);
+        perf_tests::stop_measuring_time();
+    }
+    return LOOPS;
+}
+
 // The following tests run in order check that pre-run hooks are executed properly.
 
 static int hook_1_count = 0, hook_2_count = 1;


### PR DESCRIPTION
Downstream PERF_TEST overhead stuff, let's see how many high overhead benches we have.

## Summary
- Move perf counters into time_measurement singleton for cleaner interface
- Move time_measurement class to implementation file
- Add measurement overhead tracking and warnings
- Calibrate start/stop overhead at startup by timing 1000 iterations
- Warn when overhead exceeds threshold (default 10%)
- Add --overhead-threshold and --fail-on-high-overhead options

Upstream PR: https://github.com/scylladb/seastar/pull/3209