### PR TITLE
memory: reduce large allocation warning to debug level in scoped fallback mode

### DIFF
--- a/src/core/memory.cc
+++ b/src/core/memory.cc
@@ -883,7 +883,11 @@ cpu_pages::allocate_large_and_trim(unsigned n_pages, bool should_sample) {
 void
 cpu_pages::warn_large_allocation(size_t size) {
     alloc_stats::increment_local(alloc_stats::types::large_allocs);
-    seastar_memory_logger.warn("oversized allocation: {} bytes. This is non-fatal, but could lead to latency and/or fragmentation issues. Please report: at {}", size, current_backtrace());
+    if (fallback_to_system_nest_count) {
+        seastar_memory_logger.debug("large allocation: {} bytes (in scoped fallback mode)", size);
+    } else {
+        seastar_memory_logger.warn("oversized allocation: {} bytes. This is non-fatal, but could lead to latency and/or fragmentation issues. Please report: at {}", size, current_backtrace());
+    }
 }
 
 allocation_site_ptr


### PR DESCRIPTION
## Summary
When using `scoped_system_alloc_fallback`, large allocations are expected and intentional. This reduces the log level from warn to debug to avoid spamming logs in this case.

Also changes the message text to avoid triggering the BLL check and skips the backtrace since it's not useful for expected allocations.

## Test plan
- Build with gcc/clang
- Verify large allocations in scoped fallback mode log at debug level