### PR TITLE
ci: Disable scheduling_group_nesting test in Alpine workflow

### DIFF
--- a/.github/workflows/alpinelinux.yaml
+++ b/.github/workflows/alpinelinux.yaml
@@ -64,4 +64,4 @@ jobs:
 
     - name: Run unit tests
       run: |
-        ctest --test-dir build --output-on-failure -j2
+        ctest --test-dir build --output-on-failure -j2 -E scheduling_group_nesting


### PR DESCRIPTION
## Summary
- Exclude the `scheduling_group_nesting` test from the Alpine Linux CI workflow using ctest's `-E` flag

## Background
The `scheduling_group_nesting` test has been flaking consistently in the Alpine Linux CI environment, causing spurious test failures.

## Test plan
- Verify that Alpine CI runs successfully without the flaky test
- Other CI workflows continue to run the test normally