### PR TITLE
perf_tests: increase overhead column precision to 3 decimal places

### DIFF
--- a/tests/perf/perf_tests.cc
+++ b/tests/perf/perf_tests.cc
@@ -617,7 +617,7 @@ static const std::vector<column> common_columns{
     {"tasks"   ,  3, [](const result& r) { return r.tasks;               }},
     {"inst"    ,  2, [](const result& r) { return r.inst;                }},
     {"cycles"  ,  1, [](const result& r) { return r.cycles;              }},
-    {"overhead",  1, [](const result& r) { return r.overhead;            }},
+    {"overhead",  3, [](const result& r) { return r.overhead;            }},
 };
 // json columns
 static const std::vector<column> json_columns = [] {


### PR DESCRIPTION
Display overhead values as 0.000 instead of 0.0 for finer granularity
when viewing measurement overhead in perf test output.

Upstream: https://github.com/scylladb/seastar/pull/3284