### PR TITLE
ossl: use temporary_buffer instead of scattered_message for API level 9

### DIFF
--- a/include/seastar/util/internal/iovec_utils.hh
+++ b/include/seastar/util/internal/iovec_utils.hh
@@ -51,7 +51,7 @@ inline size_t iovec_len(std::span<const iovec> iov) {
 // Can update some iovecs in-place
 inline std::span<iovec> iovec_trim_front(std::span<iovec> iov, size_t size) {
     unsigned pos = 0;
-    while (pos < iov.size() && size > 0) {
+    while (pos < iov.size()) {
         if (iov[pos].iov_len > size) {
             iov[pos].iov_base = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(iov[pos].iov_base) + size);
             iov[pos].iov_len -= size;

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -2333,14 +2333,12 @@ int bio_write_ex(BIO* b, const char * data, size_t dlen, size_t * written) {
     }
 
     try {
-        size_t n;
-
         if (!session->_output_pending.failed()) {
-            scattered_message<char> msg;
-            msg.append(std::string_view(data, dlen));
-            n = msg.size();
-            session->_output_pending = session->_out.put(std::move(msg).release());
-            tls_log.trace("{} bio_write_ex: Appended {} bytes to output pending", *session, n);
+            if (dlen > 0) {
+                temporary_buffer<char> buf(data, dlen);
+                session->_output_pending = session->_out.put(std::move(buf));
+            }
+            tls_log.trace("{} bio_write_ex: Appended {} bytes to output pending", *session, dlen);
         }
 
         if (session->_output_pending.failed()) {
@@ -2349,7 +2347,7 @@ int bio_write_ex(BIO* b, const char * data, size_t dlen, size_t * written) {
         }
 
         if (written != nullptr) {
-            *written = n;
+            *written = dlen;
         }
 
         return 1;

--- a/tests/unit/socket_test.cc
+++ b/tests/unit/socket_test.cc
@@ -546,3 +546,29 @@ SEASTAR_THREAD_TEST_CASE(inet_local_remote_address_sanity) {
     ss.wait_input_shutdown().get();
     BOOST_CHECK(ss.remote_address().is_unspecified());
 }
+
+// Regression test: data_sink::put() with a zero-length temporary_buffer used
+// to cause write_all to infinitely recurse (stack overflow) because
+// iovec_trim_front(iovs, 0) returned the same non-empty span with a
+// zero-length iovec, so no progress was made.
+// Only applies to API level >= 9 where write_all uses the iovec path;
+// at lower levels, write_all(const char*, size_t) asserts len > 0.
+#if SEASTAR_API_LEVEL >= 9
+SEASTAR_THREAD_TEST_CASE(data_sink_put_zero_length) {
+    auto addr = make_ipv4_address(11004);
+    auto ls = listen(addr);
+    auto ar_f = ls.accept();
+    auto cs = connect(addr).get();
+    auto ar = ar_f.get();
+
+    // Detach the raw data_sink to bypass output_stream's zero-length filter.
+    auto sink = std::move(cs).output().detach();
+
+    // Without the iovec_trim_front fix, this infinitely recurses and segfaults.
+    sink.put(temporary_buffer<char>()).get();
+
+    ar.connection.shutdown_input();
+    ar.connection.shutdown_output();
+    ls.abort_accept();
+}
+#endif

--- a/tests/unit/temporary_buffer_test.cc
+++ b/tests/unit/temporary_buffer_test.cc
@@ -134,3 +134,43 @@ BOOST_AUTO_TEST_CASE(test_iovec_trim_front) {
         }
     }
 }
+
+// Reproducer for a bug where iovec_trim_front returns a non-empty span
+// when all iovecs have zero length, causing write_all to loop forever
+// since no progress is made.
+BOOST_AUTO_TEST_CASE(test_iovec_trim_front_zero_length) {
+    char dummy;
+
+    // Single zero-length iovec: trimming 0 bytes should skip it
+    {
+        std::vector<iovec> iovs;
+        iovs.push_back(iovec{ &dummy, 0 });
+        auto res = internal::iovec_trim_front(std::span(iovs), 0);
+        BOOST_REQUIRE_MESSAGE(res.empty(),
+            "trim_front(0) on a single zero-length iovec must return empty span");
+    }
+
+    // Multiple zero-length iovecs
+    {
+        std::vector<iovec> iovs;
+        iovs.push_back(iovec{ &dummy, 0 });
+        iovs.push_back(iovec{ &dummy, 0 });
+        iovs.push_back(iovec{ &dummy, 0 });
+        auto res = internal::iovec_trim_front(std::span(iovs), 0);
+        BOOST_REQUIRE_MESSAGE(res.empty(),
+            "trim_front(0) on all-zero-length iovecs must return empty span");
+    }
+
+    // Zero-length iovecs before a non-zero one: should skip the empty
+    // entries and return a span starting at the non-zero iovec
+    {
+        const char* data = "abc";
+        std::vector<iovec> iovs;
+        iovs.push_back(iovec{ &dummy, 0 });
+        iovs.push_back(iovec{ (void*)data, 3 });
+        auto res = internal::iovec_trim_front(std::span(iovs), 0);
+        BOOST_REQUIRE_EQUAL(res.size(), 1);
+        BOOST_REQUIRE_EQUAL(res[0].iov_len, 3);
+        BOOST_REQUIRE_EQUAL(*reinterpret_cast<const char*>(res[0].iov_base), 'a');
+    }
+}


### PR DESCRIPTION
Replace `scattered_message` + `net::packet` with `temporary_buffer` in `bio_write_ex`, since `data_sink::put()` no longer accepts `net::packet` at API level 9. Matches the approach already used by the GnuTLS implementation in `tls.cc`.

Also fix an infinite loop in `iovec_trim_front` when given zero-length iovecs: the old loop condition `size > 0` meant zero-length entries were never skipped, so `write_all` would infinitely recurse when `sendmsg` returned 0 and trim_front made no progress. Regression tests included.

CI is updated to build at API level 9.