### PR TITLE
ossl: Share BIO ptrs across shards

### DIFF
--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -2432,9 +2432,9 @@ bio_method_ptr create_bio_method() {
 } // namespace tls
 
 BIO_METHOD* get_method() {
-    static thread_local bio_method_ptr method_ptr = [] {
-        return tls::create_bio_method();
-    }();
+    // shared across shards (no actual state) to avoid running into 127 BIO
+    // index limit in openssl on larger shard count machines
+    const static bio_method_ptr method_ptr = tls::create_bio_method();
 
     return method_ptr.get();
 }


### PR DESCRIPTION
On larger shard systems (128+) we are running into:

```
Apr 08 17:37:44 ip-172-31-25-67 rpk[11696]: WARN  2026-04-08 17:37:44,098 [shard 126:main] seastar - Exceptional future ignored: std::__1::system_error (error OpenSSL:1074528519, Failed to obtain new BIO index: error:400C0107:lib(128)::operation fail), backtrace: 0x238d4c2 0x6be7fff 0x6be82dd 0x239781c 0x22eb02f 0x22ebddb 0x2027766 0x2ec2b70 0x6b112b2 /opt/redpanda/lib/libc.so.6+0x94ac2 /opt/redpanda/lib/libc.so.6+0x12684f
```

which would then lead to SSL connections silently not working.

This is because newer ossl versions only accept 127 entries. Previous
versions would silently accept up to 255 with some silent possible
benign corruption (https://github.com/openssl/openssl/commit/d78519e74e7aa538eb28918aa8ec87c49f688c11).

Share the BIO methods across shards. They don't contain state so are safe to
share.

Co-authored-by: Alexey Bashtanov <alexey.bashtanov@redpanda.com>
Co-authored-by: Tyler Rockwood <rockwood@redpanda.com>