### PR TITLE
[v25.2.x] Backport ossl BIO fix

### DIFF
--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -2188,14 +2188,13 @@ bio_method_ptr create_bio_method() {
 } // namespace tls
 
 BIO_METHOD* get_method() {
-    static thread_local bio_method_ptr method_ptr = [] {
-        auto ptr = tls::create_bio_method();
-        if (!ptr) {
-            throw make_ossl_error("Failed to construct BIO method");
-        }
-        return ptr;
-    }();
-    
+    // shared across shards (no actual state) to avoid running into 127 BIO
+    // index limit in openssl on larger shard count machines
+    const static bio_method_ptr method_ptr = tls::create_bio_method();
+    if (!method_ptr) {
+        throw make_ossl_error("Failed to construct BIO method");
+    }
+
     return method_ptr.get();
 }
 


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/seastar/pull/264

With slight adjustment as 25.2 still has this extra check which vanished in the rebase.