### PR TITLE
Backport v25.2.x: Disable scheduling_group_nesting test in Alpine workflow

### DIFF
--- a/.github/workflows/alpinelinux.yaml
+++ b/.github/workflows/alpinelinux.yaml
@@ -63,4 +63,4 @@ jobs:
 
     - name: Run unit tests
       run: |
-        ctest --test-dir build --output-on-failure -j2
+        ctest --test-dir build --output-on-failure -j2 -E scheduling_group_nesting


### PR DESCRIPTION
The scheduling_group_nesting test is flaking consistently in the Alpine Linux CI environment. Exclude it from the test run until the flakiness can be resolved.