### PR TITLE
`util`: add `force_tag` overloads to logging utilities

### DIFF
--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -71,6 +71,14 @@ class logger {
 #endif
 
 public:
+    /// Tag used to request that a log call bypass the configured level
+    /// gate. Passed as the first argument to any force-suffixed overload
+    /// or to the per-level helpers. A distinct type (not bool) avoids
+    /// ambiguity with the format_info-first overloads: a string literal
+    /// converts to format_info but not to force_tag.
+    struct force_tag {};
+    static constexpr force_tag force{};
+
     class log_writer {
     public:
         virtual ~log_writer() = default;
@@ -251,20 +259,7 @@ public:
     ///
     template <typename... Args>
     void log(log_level level, format_info_t<Args...> fmt, Args&&... args) noexcept {
-        if (is_enabled(level)) {
-            try {
-                lambda_log_writer writer([&] (internal::log_buf::inserter_iterator it) {
-#ifdef SEASTAR_LOGGER_COMPILE_TIME_FMT
-                    return fmt::format_to(it, fmt.format, std::forward<Args>(args)...);
-#else
-                    return fmt::format_to(it, fmt::runtime(fmt.format), std::forward<Args>(args)...);
-#endif
-                });
-                do_log(level, writer);
-            } catch (...) {
-                failed_to_log(std::current_exception(), fmt::string_view(fmt.format), fmt.loc);
-            }
-        }
+        do_log_checked(level, false, std::move(fmt), std::forward<Args>(args)...);
     }
 
     /// logs with a rate limit to desired level if enabled, otherwise we ignore the log line
@@ -283,19 +278,7 @@ public:
     ///
     template <typename... Args>
     void log(log_level level, rate_limit& rl, format_info_t<Args...> fmt, Args&&... args) noexcept {
-        if (is_enabled(level) && rl.check()) {
-            try {
-                lambda_log_writer writer([&] (internal::log_buf::inserter_iterator it) {
-                    if (rl.has_dropped_messages()) {
-                        it = fmt::format_to(it, "(rate limiting dropped {} similar messages) ", rl.get_and_reset_dropped_messages());
-                    }
-                    return fmt::format_to(it, fmt::runtime(fmt.format), std::forward<Args>(args)...);
-                });
-                do_log(level, writer);
-            } catch (...) {
-                failed_to_log(std::current_exception(), fmt::string_view(fmt.format), fmt.loc);
-            }
-        }
+        do_log_checked_rl(level, false, rl, std::move(fmt), std::forward<Args>(args)...);
     }
 
     /// \cond internal
@@ -457,6 +440,42 @@ public:
     ///
     /// \note this is a noop if fmtlib's version is less than 6.0
     static void set_with_color(bool enabled) noexcept;
+
+private:
+    template <typename... Args>
+    void do_log_checked(log_level level, bool bypass, format_info_t<Args...> fmt, Args&&... args) noexcept {
+        if (bypass || is_enabled(level)) {
+            try {
+                lambda_log_writer writer([&] (internal::log_buf::inserter_iterator it) {
+#ifdef SEASTAR_LOGGER_COMPILE_TIME_FMT
+                    return fmt::format_to(it, fmt.format, std::forward<Args>(args)...);
+#else
+                    return fmt::format_to(it, fmt::runtime(fmt.format), std::forward<Args>(args)...);
+#endif
+                });
+                do_log(level, writer);
+            } catch (...) {
+                failed_to_log(std::current_exception(), fmt::string_view(fmt.format), fmt.loc);
+            }
+        }
+    }
+
+    template <typename... Args>
+    void do_log_checked_rl(log_level level, bool bypass, rate_limit& rl, format_info_t<Args...> fmt, Args&&... args) noexcept {
+        if ((bypass || is_enabled(level)) && rl.check()) {
+            try {
+                lambda_log_writer writer([&] (internal::log_buf::inserter_iterator it) {
+                    if (rl.has_dropped_messages()) {
+                        it = fmt::format_to(it, "(rate limiting dropped {} similar messages) ", rl.get_and_reset_dropped_messages());
+                    }
+                    return fmt::format_to(it, fmt::runtime(fmt.format), std::forward<Args>(args)...);
+                });
+                do_log(level, writer);
+            } catch (...) {
+                failed_to_log(std::current_exception(), fmt::string_view(fmt.format), fmt.loc);
+            }
+        }
+    }
 };
 
 /// \brief used to keep a static registry of loggers

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -351,6 +351,11 @@ public:
     void error(format_info_t<Args...> fmt, Args&&... args) noexcept {
         log(log_level::error, std::move(fmt), std::forward<Args>(args)...);
     }
+    /// Force-emit variant: bypass the level gate. See \ref force_tag.
+    template <typename... Args>
+    void error(force_tag, format_info_t<Args...> fmt, Args&&... args) noexcept {
+        log(log_level::error, force, std::move(fmt), std::forward<Args>(args)...);
+    }
     /// Log with warning tag:
     /// WARN  %Y-%m-%d %T,%03d [shard 0] - "your msg" \n
     ///
@@ -362,6 +367,11 @@ public:
     void warn(format_info_t<Args...> fmt, Args&&... args) noexcept {
         log(log_level::warn, std::move(fmt), std::forward<Args>(args)...);
     }
+    /// Force-emit variant: bypass the level gate. See \ref force_tag.
+    template <typename... Args>
+    void warn(force_tag, format_info_t<Args...> fmt, Args&&... args) noexcept {
+        log(log_level::warn, force, std::move(fmt), std::forward<Args>(args)...);
+    }
     /// Log with info tag:
     /// INFO  %Y-%m-%d %T,%03d [shard 0] - "your msg" \n
     ///
@@ -372,6 +382,11 @@ public:
     template <typename... Args>
     void info(format_info_t<Args...> fmt, Args&&... args) noexcept {
         log(log_level::info, std::move(fmt), std::forward<Args>(args)...);
+    }
+    /// Force-emit variant: bypass the level gate. See \ref force_tag.
+    template <typename... Args>
+    void info(force_tag, format_info_t<Args...> fmt, Args&&... args) noexcept {
+        log(log_level::info, force, std::move(fmt), std::forward<Args>(args)...);
     }
     /// Log with info tag on shard zero only:
     /// INFO  %Y-%m-%d %T,%03d [shard 0] - "your msg" \n
@@ -386,6 +401,13 @@ public:
             log(log_level::info, std::move(fmt), std::forward<Args>(args)...);
         }
     }
+    /// Force-emit variant: bypass the level gate. See \ref force_tag.
+    template <typename... Args>
+    void info0(force_tag, format_info_t<Args...> fmt, Args&&... args) noexcept {
+        if (is_shard_zero()) {
+            log(log_level::info, force, std::move(fmt), std::forward<Args>(args)...);
+        }
+    }
     /// Log with debug tag:
     /// DEBUG  %Y-%m-%d %T,%03d [shard 0] - "your msg" \n
     ///
@@ -397,6 +419,11 @@ public:
     void debug(format_info_t<Args...> fmt, Args&&... args) noexcept {
         log(log_level::debug, std::move(fmt), std::forward<Args>(args)...);
     }
+    /// Force-emit variant: bypass the level gate. See \ref force_tag.
+    template <typename... Args>
+    void debug(force_tag, format_info_t<Args...> fmt, Args&&... args) noexcept {
+        log(log_level::debug, force, std::move(fmt), std::forward<Args>(args)...);
+    }
     /// Log with trace tag:
     /// TRACE  %Y-%m-%d %T,%03d [shard 0] - "your msg" \n
     ///
@@ -407,6 +434,11 @@ public:
     template <typename... Args>
     void trace(format_info_t<Args...> fmt, Args&&... args) noexcept {
         log(log_level::trace, std::move(fmt), std::forward<Args>(args)...);
+    }
+    /// Force-emit variant: bypass the level gate. See \ref force_tag.
+    template <typename... Args>
+    void trace(force_tag, format_info_t<Args...> fmt, Args&&... args) noexcept {
+        log(log_level::trace, force, std::move(fmt), std::forward<Args>(args)...);
     }
 
     /// \return name of the logger. Usually one logger per module

--- a/include/seastar/util/log.hh
+++ b/include/seastar/util/log.hh
@@ -262,6 +262,12 @@ public:
         do_log_checked(level, false, std::move(fmt), std::forward<Args>(args)...);
     }
 
+    /// Force-emit variant: bypass the level gate. See \ref force_tag.
+    template <typename... Args>
+    void log(log_level level, force_tag, format_info_t<Args...> fmt, Args&&... args) noexcept {
+        do_log_checked(level, true, std::move(fmt), std::forward<Args>(args)...);
+    }
+
     /// logs with a rate limit to desired level if enabled, otherwise we ignore the log line
     ///
     /// If there were messages dropped due to rate-limiting the following snippet
@@ -279,6 +285,13 @@ public:
     template <typename... Args>
     void log(log_level level, rate_limit& rl, format_info_t<Args...> fmt, Args&&... args) noexcept {
         do_log_checked_rl(level, false, rl, std::move(fmt), std::forward<Args>(args)...);
+    }
+
+    /// Force-emit rate-limited variant: bypass the level gate (the rate
+    /// limit itself still applies).
+    template <typename... Args>
+    void log(log_level level, force_tag, rate_limit& rl, format_info_t<Args...> fmt, Args&&... args) noexcept {
+        do_log_checked_rl(level, true, rl, std::move(fmt), std::forward<Args>(args)...);
     }
 
     /// \cond internal

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -769,6 +769,9 @@ seastar_add_test (weak_ptr
 seastar_add_test (log_buf
   SOURCES log_buf_test.cc)
 
+seastar_add_test (logger_force
+  SOURCES logger_force_test.cc)
+
 seastar_add_test (exception_logging
   KIND BOOST
   SOURCES exception_logging_test.cc)

--- a/tests/unit/logger_force_test.cc
+++ b/tests/unit/logger_force_test.cc
@@ -1,0 +1,42 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/log.hh>
+
+#include <sstream>
+
+namespace {
+seastar::logger test_log("test");
+}
+
+SEASTAR_THREAD_TEST_CASE(force_bypasses_level_gate_log_overload) {
+    std::ostringstream captured;
+    seastar::logger::set_ostream(captured);
+    seastar::logger::set_ostream_enabled(true);
+
+    test_log.set_level(seastar::log_level::warn);
+
+    // Without force: dropped.
+    test_log.log(seastar::log_level::info, "dropped_line");
+    BOOST_REQUIRE(captured.str().find("dropped_line") == std::string::npos);
+
+    // With force: emitted.
+    test_log.log(seastar::log_level::info, seastar::logger::force, "forced_line");
+    BOOST_REQUIRE(captured.str().find("forced_line") != std::string::npos);
+}

--- a/tests/unit/logger_force_test.cc
+++ b/tests/unit/logger_force_test.cc
@@ -40,3 +40,29 @@ SEASTAR_THREAD_TEST_CASE(force_bypasses_level_gate_log_overload) {
     test_log.log(seastar::log_level::info, seastar::logger::force, "forced_line");
     BOOST_REQUIRE(captured.str().find("forced_line") != std::string::npos);
 }
+
+SEASTAR_THREAD_TEST_CASE(force_bypasses_level_gate_convenience_methods) {
+    std::ostringstream captured;
+    seastar::logger::set_ostream(captured);
+    seastar::logger::set_ostream_enabled(true);
+
+    test_log.set_level(seastar::log_level::warn);
+
+    test_log.info(seastar::logger::force, "info_forced");
+    test_log.debug(seastar::logger::force, "debug_forced");
+    test_log.trace(seastar::logger::force, "trace_forced");
+    test_log.warn(seastar::logger::force, "warn_forced");
+    test_log.error(seastar::logger::force, "error_forced");
+
+    const auto out = captured.str();
+    BOOST_REQUIRE(out.find("info_forced")  != std::string::npos);
+    BOOST_REQUIRE(out.find("debug_forced") != std::string::npos);
+    BOOST_REQUIRE(out.find("trace_forced") != std::string::npos);
+    BOOST_REQUIRE(out.find("warn_forced")  != std::string::npos);
+    BOOST_REQUIRE(out.find("error_forced") != std::string::npos);
+
+    // Without force, info/debug/trace dropped under warn level.
+    captured.str("");
+    test_log.info("info_dropped");
+    BOOST_REQUIRE(captured.str().find("info_dropped") == std::string::npos);
+}


### PR DESCRIPTION
Enablement for https://github.com/redpanda-data/redpanda/pull/30202.

This will allow us to force specific log lines on, regardless of the currently configured global logging level.