### PR TITLE
CORE-15655 Forward port ossl changes to dev / 26.2.x-pre

### DIFF
--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -1825,6 +1825,17 @@ SEASTAR_INTERNAL_END_IGNORE_DEPRECATIONS
     }
 
 private:
+    // Some SSL operations return success while leaving stale errors on the
+    // queue (e.g. from internal BIO write failures that OpenSSL absorbed).
+    // Drain them so they don't poison the next operation on this shard.
+    void clear_stale_ssl_errors(const char* operation) {
+        if (ERR_peek_error() == 0) [[likely]] {
+            return;
+        }
+        auto errors = get_all_ossl_errors();
+        tls_log.debug("{} {}: ignoring stale errors on queue: {}", *this, operation, errors);
+    }
+
     std::vector<subject_alt_name> do_get_alt_name_information(const x509_ptr &peer_cert,
                                                               const std::unordered_set<subject_alt_name_type> &types) const {
         int ext_idx = X509_get_ext_by_NID(
@@ -1993,6 +2004,11 @@ private:
             throw make_ossl_error(
               "Failed to initialize SSL context");
         }
+        // SSL_CTX_new can return a valid context while leaving errors on the
+        // error queue from partially-failed system config parsing (e.g. an
+        // invalid Ciphersuites value in the system openssl.cnf).
+        // See https://github.com/openssl/openssl/issues/30760
+        clear_stale_ssl_errors("SSL_CTX_new");
         const auto& ck_pair = _creds->get_certkey_pair();
         if (type == session_type::SERVER) {
             if (!ck_pair) {

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -1195,6 +1195,7 @@ public:
         // This do_until runs until either a renegotiation occurs or the packet is empty
         while (!eof() && size > 0) {
             size_t bytes_written = 0;
+            verify_clean_error_queue("SSL_write_ex");
             auto write_rc = SSL_write_ex(_ssl.get(), ptr, size, &bytes_written);
             tls_log.trace("{} do_put: SSL_write_ex: {}", *this, write_rc);
             if (write_rc != 1) {
@@ -1287,6 +1288,7 @@ public:
             [this] { return connected() || eof(); },
             [this] {
                 try {
+                    verify_clean_error_queue("SSL_do_handshake");
                     auto n = SSL_do_handshake(_ssl.get());
                     tls_log.trace("{} do_handshake: SSL_do_handshake: {}", *this, n);
                     if (n <= 0) {
@@ -1399,6 +1401,7 @@ public:
             tls_log.trace("{} do_get: available: {}", *this, avail);
             buf_type buf(avail);
             size_t bytes_read = 0;
+            verify_clean_error_queue("SSL_read_ex");
             auto read_result = SSL_read_ex(
               _ssl.get(), buf.get_write(), avail, &bytes_read);
             tls_log.trace("{} do_get: SSL_read_ex: {}", *this, read_result);
@@ -1495,6 +1498,7 @@ public:
             return make_ready_future();
         }
 
+        verify_clean_error_queue("SSL_shutdown");
         auto res = SSL_shutdown(_ssl.get());
         tls_log.trace("{} do_shutdown: SSL_shutdown: {}", *this, res);
         if (res == 1) {
@@ -1839,6 +1843,22 @@ private:
         }
         auto errors = get_all_ossl_errors();
         tls_log.debug("{} {}: ignoring stale errors on queue: {}", *this, operation, errors);
+    }
+
+    // Checks that the OpenSSL per-thread error queue is clean before
+    // calling an SSL function.  A dirty queue can cause SSL_get_error
+    // to misclassify results (e.g. reporting SSL_ERROR_SYSCALL instead
+    // of SSL_ERROR_SSL), which can affect unrelated sessions that share
+    // the same thread.
+    void verify_clean_error_queue(const char* operation) {
+        auto err = ERR_peek_error();
+        if (err == 0) [[likely]] {
+            return;
+        }
+        char buf[256];
+        ERR_error_string_n(err, buf, sizeof(buf));
+        tls_log.warn("{} stale error on queue before {}: {}", *this, operation, buf);
+        SEASTAR_ASSERT(0 && "stale errors on OpenSSL error queue");
     }
 
     std::vector<subject_alt_name> do_get_alt_name_information(const x509_ptr &peer_cert,

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -183,6 +183,10 @@ std::system_error make_ossl_error(const std::string & msg) {
     return make_ossl_error(msg, get_all_ossl_errors());
 }
 
+std::runtime_error make_unknown_ossl_error(const std::string & msg) {
+    return std::runtime_error(fmt::format("{}: {}", msg, get_all_ossl_errors()));
+}
+
 bool contains_ossl_error(const std::vector<ossl_errc> & error_codes, int lib, int reason) {
     return std::any_of(error_codes.cbegin(), error_codes.cend(), [lib, reason](const ossl_errc & code) {
         return ERR_GET_LIB(static_cast<unsigned long>(code)) == lib &&
@@ -1151,7 +1155,7 @@ public:
         default:
         {
             // Some other unhandled situation
-            auto err = std::runtime_error(
+            auto err = make_unknown_ossl_error(
                 "Unknown error encountered during SSL write");
             return handle_output_error(std::move(err)).then([] {
                 return stop_iteration::yes;
@@ -1326,7 +1330,7 @@ public:
                             return handle_output_error(std::move(err));
                         }
                         default:
-                            auto err = std::runtime_error(
+                            auto err = make_unknown_ossl_error(
                             "Unknown error encountered during handshake");
                             return handle_output_error(std::move(err));
                         }
@@ -1451,7 +1455,7 @@ public:
                         return make_exception_future<buf_type>(_error);
                     }
                 default:
-                    _error = std::make_exception_ptr(std::runtime_error(
+                    _error = std::make_exception_ptr(make_unknown_ossl_error(
                       "Unexpected error condition during SSL read"));
                     return make_exception_future<buf_type>(_error);
                 }
@@ -1536,7 +1540,7 @@ public:
             }
             default:
             {
-                auto err = std::runtime_error(
+                auto err = make_unknown_ossl_error(
                   "Unknown error occurred during SSL shutdown");
                 return handle_output_error(std::move(err));
             }

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -1023,7 +1023,7 @@ public:
         bio_ptr in_bio(BIO_new(get_method()));
         bio_ptr out_bio(BIO_new(get_method()));
         if (!in_bio || !out_bio) {
-            throw std::runtime_error("Failed to create BIOs");
+            throw make_ossl_error("Failed to create BIOs");
         }
         if (1 != BIO_ctrl(in_bio.get(), BIO_C_SET_POINTER, 0, this)) {
             throw make_ossl_error("Failed to set bio ptr to in bio");

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -1205,6 +1205,7 @@ public:
                     co_return;
                 }
             } else {
+                clear_stale_ssl_errors("SSL_write_ex");
                 SEASTAR_ASSERT(bytes_written <= size);
                 tls_log.trace("{} do_put: bytes_written: {}", *this, bytes_written);
                 ptr += bytes_written;
@@ -1335,6 +1336,7 @@ public:
                             return handle_output_error(std::move(err));
                         }
                     } else {
+                        clear_stale_ssl_errors("SSL_do_handshake");
                         if (_type == session_type::CLIENT
                             || _creds->get_client_auth() != client_auth::NONE) {
                             verify();
@@ -1460,6 +1462,7 @@ public:
                     return make_exception_future<buf_type>(_error);
                 }
             } else {
+                clear_stale_ssl_errors("SSL_read_ex");
                 buf.trim(bytes_read);
                 return make_ready_future<buf_type>(std::move(buf));
             }
@@ -1495,8 +1498,10 @@ public:
         auto res = SSL_shutdown(_ssl.get());
         tls_log.trace("{} do_shutdown: SSL_shutdown: {}", *this, res);
         if (res == 1) {
+            clear_stale_ssl_errors("SSL_shutdown");
             return wait_for_output();
         } else if (res == 0) {
+            clear_stale_ssl_errors("SSL_shutdown");
             return yield().then([this] { return do_shutdown(); });
         } else {
             auto ssl_err = SSL_get_error(_ssl.get(), res);

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -2430,9 +2430,9 @@ bio_method_ptr create_bio_method() {
 } // namespace tls
 
 BIO_METHOD* get_method() {
-    static thread_local bio_method_ptr method_ptr = [] {
-        return tls::create_bio_method();
-    }();
+    // shared across shards (no actual state) to avoid running into 127 BIO
+    // index limit in openssl on larger shard count machines
+    const static bio_method_ptr method_ptr = tls::create_bio_method();
 
     return method_ptr.get();
 }


### PR DESCRIPTION
Redpanda dev currently points to [26.2.x-pre](https://github.com/redpanda-data/redpanda/blob/8094a0e029aa9da80c6e01c636286728f302a5ad/bazel/repositories.bzl#L173) of seastar, so this forward ports the recent seastar changes made to 26.1.x to our dev branch as well.

[Diff](https://github.com/redpanda-data/seastar/compare/v26.2.x-pre...redpanda-data:seastar:v26.1.x?expand=1):
- https://github.com/redpanda-data/seastar/pull/264
- https://github.com/redpanda-data/seastar/pull/267