### PR TITLE
ossl: error queue assert to only terminate in debug builds

### DIFF
--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -1858,7 +1858,7 @@ private:
         char buf[256];
         ERR_error_string_n(err, buf, sizeof(buf));
         tls_log.warn("{} stale error on queue before {}: {}", *this, operation, buf);
-        SEASTAR_ASSERT(0 && "stale errors on OpenSSL error queue");
+        assert(0 && "stale errors on OpenSSL error queue");
     }
 
     std::vector<subject_alt_name> do_get_alt_name_information(const x509_ptr &peer_cert,


### PR DESCRIPTION
Openssl's api contract is too loose and the impact to wide (e.g. low-priority https traffic could crash the whole process) that it makes sense to only terminate here in debug builds.

CORE-15655