### PR TITLE
file: fix default DMA alignment

### DIFF
--- a/src/core/file.cc
+++ b/src/core/file.cc
@@ -1208,7 +1208,7 @@ internal::alignments filesystem_alignments(
     // Initialize with generic defaults for all filesystems
     internal::alignments align = {
         .memory = std::max(device_info.memory_alignment.value_or(4096), internal::min_memory_alignment),
-        .disk_read = 512,  // Linux O_DIRECT minimum
+        .disk_read = block_size,  // Linux O_DIRECT safe choice, might be reduced later
         .disk_write = block_size,
         .disk_overwrite = block_size,
     };


### PR DESCRIPTION
Cherry-pick of upstream scylladb/seastar `753faf34c` (PR scylladb/seastar#3402): `file: fix default DMA alignment`.

This is important for our v26.2.x: we recently brought in the regression that this fixes as part of the v26.2.x rebase. Upstream commit `15adc3ce5` ("file: Apply physical_block_size override to filesystem files") inadvertently changed the default DMA alignment for `file::_disk_read_dma_alignment` from 4096 down to 512 (the Linux O_DIRECT minimum). When we have no other source of alignment info, that 512-byte default is what ends up being used — and it does not work on devices with 4096-byte sectors.

The fix changes the default to the filesystem block size, which should always work (it can still be overridden later by XFS-specific code).

15adc3ce5 landed in v26.2.x via our rebase, so v26.2.x ships the broken behavior today; v26.1.x and earlier are unaffected. Worth getting in before the release.