### PR TITLE
[v25.3.x] net/tls: Fix concurrent put() on the socket in the OpenSSL backend

### DIFF
--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -1234,6 +1234,22 @@ public:
         });
     }
 
+    // Test-only hook used by tls_test.cc to reproduce the concurrent put()
+    // this change fixes. It is intentionally not part of the public TLS API
+    // (the OpenSSL backend on this branch has no rehandshake/key-update entry
+    // point): it simply requests a TLS 1.3 key update on this (server) session,
+    // so the peer's read path emits a key-update response -- the read-path
+    // put() the reproducer needs. Reached from the test via the free function
+    // trigger_key_update_for_test(connected_socket&) defined below.
+    future<> trigger_key_update_for_test() {
+        return with_semaphore(_out_sem, 1, [this] {
+            if (!SSL_key_update(_ssl.get(), SSL_KEY_UPDATE_REQUESTED)) {
+                throw make_ossl_error("SSL_key_update failed");
+            }
+            return wait_for_output();
+        });
+    }
+
     // Called after locking the _in_sem and _out_sem semaphores.
     // This function will walk through the handshake with a remote peer
     // If EOF is encountered, ENOTCONN is thrown
@@ -2171,6 +2187,18 @@ private:
     friend int session_ticket_cb(SSL*, unsigned char[16], unsigned char[EVP_MAX_IV_LENGTH],
                                  EVP_CIPHER_CTX*, EVP_MAC_CTX*, int);
 };
+
+// Test-only hook, implemented here for the OpenSSL backend and intentionally
+// not declared in any public header. tls_test.cc forward-declares it to drive
+// the concurrent-put reproducer; production code must not depend on it. See
+// session::trigger_key_update_for_test() for what it does and why.
+future<> trigger_key_update_for_test(connected_socket& socket) {
+    auto* impl = net::get_impl::maybe_get_ptr(socket);
+    auto* tls_impl = dynamic_cast<tls_connected_socket_impl*>(impl);
+    SEASTAR_ASSERT(tls_impl);
+    auto* sess = static_cast<session*>(tls_impl->_session.get());
+    return sess->trigger_key_update_for_test();
+}
 
 // The following callback function is used whenever session tickets are generated or received by
 // the TLS server.  If TLS session resumption is enabled, then an AES and HMAC key are

--- a/src/net/ossl.cc
+++ b/src/net/ossl.cc
@@ -70,6 +70,7 @@ module;
 module seastar;
 #else
 #include <seastar/core/gate.hh>
+#include <seastar/core/shared_future.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/with_timeout.hh>
 #include <seastar/net/stack.hh>
@@ -1072,11 +1073,24 @@ public:
         return _type == session_type::CLIENT ? "Client": "Server";
     }
 
-    // This function waits for the _output_pending future to resolve
-    // If an error occurs, it is saved off into _error and returned
+    // Resolves when the put() currently tracked by _output_pending has drained;
+    // if it failed, the error is recorded in _error and re-raised.
+    //
+    // Awaits via get_future() so _output_pending keeps tracking the in-flight
+    // put() -- bio_write_ex()'s guard reads available()/failed() on it, and that
+    // has to stay truthful while the put drains (see the _output_pending
+    // declaration).
+    //
+    // On failure _output_pending is left failed rather than reset to ready. A
+    // failed _output_pending is a circuit breaker: bio_write_ex() issues no
+    // further puts and re-raises, entry points bail on _error, and the session
+    // tears down. Resetting it here would mutate _output_pending from a
+    // completion continuation, which would have to be shown not to race with a
+    // put() issued in the meantime and clobber a live one; leaving it failed
+    // avoids that, and is harmless since an output failure is terminal.
     future<> wait_for_output() {
         tls_log.trace("{} wait_for_output", *this);
-        return std::exchange(_output_pending, make_ready_future())
+        return _output_pending.get_future()
           .handle_exception([this](auto ep) {
               tls_log.debug("{} wait_for_output error: {}", *this, ep);
               _error = ep;
@@ -1166,7 +1180,13 @@ public:
     // any unprocessed part of the packet is returned.
     future<> do_put(net::packet p) {
         tls_log.trace("{} do_put", *this);
-        SEASTAR_ASSERT(_output_pending.available());
+
+        // A key-update put() from the read path (under _in_sem) may still be in
+        // flight here; we hold only _out_sem, which does not exclude it. No
+        // up-front drain is needed: bio_write_ex() declines while a put is in
+        // flight, so the first SSL_write_ex reports WANT_WRITE and
+        // handle_do_put_ssl_err() drains and retries, like every later loop
+        // iteration.
         return do_with(std::move(p),
             [this](net::packet& p) {
                 // This do_until runs until either a renegotiation occurs or the packet is empty
@@ -2164,11 +2184,84 @@ private:
     data_sink _out;
     std::exception_ptr _error;
 
+    // A session wraps one SSL object over one bidirectional socket. Reads and
+    // writes are allowed to run concurrently (full duplex), serialized by two
+    // *disjoint* semaphores:
+    //
+    //   _in_sem   guards the read path:  get() -> do_get() -> SSL_read_ex, and
+    //             wait_for_eof() during shutdown.
+    //   _out_sem  guards the write path: put() -> do_put() -> SSL_write_ex,
+    //             plus flush() and do_shutdown().
+    //
+    // Operations that span both directions take both semaphores, always in the
+    // order _in_sem then _out_sem (handshake(), and the final drain in close()).
+    // Nothing acquires them in the opposite order, so there is no deadlock.
+    //
+    // The important consequence: because the two semaphores are disjoint, a read
+    // and a write can be in flight at the same time, and *both* can end up
+    // writing to the underlying socket -- the write path always does, and the
+    // read path does too whenever SSL_read_ex emits a TLS key-update /
+    // renegotiation message while processing an incoming record. So neither
+    // semaphore serializes socket writes against the other; that serialization
+    // is handled separately, on _output_pending (see below).
     semaphore _in_sem;
     semaphore _out_sem;
     tls_options _options;
 
-    future<> _output_pending;
+    // Serializing writes to the underlying socket (_out)
+    //
+    // _out is a data_sink, which permits only one put() in flight at a time
+    // (posix_data_sink_impl asserts !_p). Per the locking model above, the read
+    // and write paths can both reach _out.put() and are not serialized against
+    // each other, so that one-put-at-a-time invariant is maintained here.
+    //
+    // It is maintained by a cooperative protocol rather than a lock: the put is
+    // issued from bio_write_ex(), a synchronous OpenSSL callback that cannot
+    // co_await, so there is nowhere to hold a lock across it. _output_pending is
+    // the protocol's state -- the put() currently in flight on _out, or a
+    // resolved future when _out is idle. bio_write_ex(), the only caller of
+    // _out.put(), consults it:
+    //   * if it is unresolved a put() is in flight: decline (BIO_set_retry_write),
+    //     OpenSSL reports WANT_WRITE, and the caller drains via wait_for_output()
+    //     before retrying;
+    //   * otherwise issue the put() and reassign _output_pending to it (that
+    //     reassignment, not any reset, is how the slot is reused).
+    // The decline/retry above is what bounds it to one in-flight put: a put from
+    // either path is declined while another is outstanding and retried after a
+    // wait_for_output(). At most one _out.put() is ever outstanding.
+    //
+    // That guard is race-free on its own: bio_write_ex() runs on the single
+    // reactor thread and does not await, so its "check _output_pending, then
+    // issue+reassign" is atomic. But it is correct only while
+    // _output_pending.available() reflects whether a put() is really in flight.
+    // That truthfulness is what shared_future buys: get_future() hands out an
+    // awaitable backed by the in-flight put() without consuming or replacing
+    // _output_pending, so available()/failed() keep reflecting it while it
+    // drains, and it can be called any number of times, so several fibers (a
+    // write and a concurrent read) can await the same put() at once. A plain
+    // future cannot be awaited without moving it out of the slot, which would
+    // falsify available() and let the guard issue a second, concurrent put() --
+    // the bug this design exists to prevent (the commit message walks the
+    // interleaving).
+    //
+    // Each _out.put() gets its own shared_future state. The first
+    // wait_for_output() calls get_future() on the unresolved shared_future, which
+    // queues a promise for the returned future and wires the state as that put's
+    // completion continuation (future::set_task), pinning it alive (_keepaliver).
+    // When that put completes the reactor runs the state's run_and_dispose(),
+    // which fulfills every queued promise -- resolving the futures
+    // wait_for_output() handed out -- then drops the pin. Reassigning
+    // _output_pending makes a fresh state for the new put and drops the handle to
+    // the old one, but does not touch the old state's wiring or its waiters, so a
+    // waiter resolves off the put it actually waited on. _output_pending is a
+    // handle to "the current put", not the channel that resolves earlier waiters.
+    //
+    // _output_pending is reassigned only when resolved and not failed. On failure
+    // it is left failed: bio_write_ex() then issues no further puts and re-raises,
+    // wait_for_output() records _error, and entry points bail. An _out.put()
+    // failure is terminal (the socket is gone), so there is no next write; see
+    // wait_for_output() for why it is not reset.
+    shared_future<> _output_pending;
     buf_type _input;
     // ALPN protocols in OPENSSL format
     // This is a sequence of length-prefixed strings, where the first byte is the length
@@ -2312,18 +2405,24 @@ int bio_create(BIO*) {
     return 1;
 }
 
-/// Handles writes to the BIO
+/// Handles writes to the BIO -- the only place that calls _out.put().
 ///
-/// This function will attempt to call _out.put() and store the future in
-/// _output_pending.  If _output_pending has not yet resolved, return '0'
-/// and set the retry write flag.
+/// This is where the one-put-at-a-time invariant is enforced (see the
+/// _output_pending declaration): a new put() is issued only when the previous
+/// one has resolved. OpenSSL calls this synchronously from SSL_read/SSL_write,
+/// so we cannot block here; instead, if a put() is still in flight we decline
+/// with BIO_set_retry_write() and let the caller drain it via wait_for_output()
+/// and retry once OpenSSL reports WANT_WRITE.
 int bio_write_ex(BIO* b, const char * data, size_t dlen, size_t * written) {
     auto session = unwrap_bio_ptr(b);
     tls_log.trace("{} bio_write_ex: dlen {}", *session, dlen);
     BIO_clear_retry_flags(b);
 
+    // A put() is still draining (or never started): refuse, ask OpenSSL to
+    // retry later. This is the mutual-exclusion check -- it is honest only
+    // because wait_for_output() does not mark _output_pending ready early.
     if (!session->_output_pending.available()) {
-        tls_log.trace("{} bio_write_ex: nothing pending in output", *session);
+        tls_log.trace("{} bio_write_ex: put still in flight", *session);
         BIO_set_retry_write(b);
         return 0;
     }
@@ -2331,17 +2430,19 @@ int bio_write_ex(BIO* b, const char * data, size_t dlen, size_t * written) {
     try {
         size_t n;
 
+        // Skip issuing if a previous put() failed; the failed _output_pending is
+        // re-raised just below and the session tears down (see wait_for_output).
         if (!session->_output_pending.failed()) {
             scattered_message<char> msg;
             msg.append(std::string_view(data, dlen));
             n = msg.size();
             session->_output_pending = session->_out.put(std::move(msg).release());
-            tls_log.trace("{} bio_write_ex: Appended {} bytes to output pending", *session, n);
+            tls_log.trace("{} bio_write_ex: issued put of {} bytes", *session, n);
         }
 
         if (session->_output_pending.failed()) {
             tls_log.debug("{} bio_write_ex: output pending has error", *session);
-            std::rethrow_exception(session->_output_pending.get_exception());
+            std::rethrow_exception(session->_output_pending.get_future().get_exception());
         }
 
         if (written != nullptr) {

--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -2270,3 +2270,201 @@ SEASTAR_THREAD_TEST_CASE(test_early_server_disconnect) {
 
     auto _ = tls::wrap_client(creds, std::move(c), tls::tls_options{}).get();
 }
+
+// Reproduces a production crash specific to the OpenSSL TLS backend:
+//
+//   SEASTAR_ASSERT(!_p);   // posix_data_sink_impl::put(packet), posix-stack.cc
+//
+// The TLS read and write paths use separate semaphores (_in_sem vs _out_sem),
+// and both can write to the underlying socket. The read path produces output
+// while processing an incoming TLS key-update/renegotiation: OpenSSL flushes a
+// pending key-update response from *inside* SSL_read_ex, pushing it out as a
+// put() on the underlying data_sink. If an application write is in flight on
+// that sink at the same time, the read issues a second, concurrent put() --
+// which posix_data_sink_impl forbids (it only tolerates one in-flight put at a
+// time), tripping the assert. The defective guard is wait_for_output()
+// swapping _output_pending for a ready future before the put actually drains.
+//
+// GnuTLS surfaces a rehandshake to the caller and re-runs the handshake while
+// holding *both* semaphores, so it never issues that concurrent put; hence
+// this is OpenSSL-specific and the test is compiled out under the GnuTLS
+// backend.
+//
+// The test installs an instrumented data_sink under the client that flags any
+// put() issued while another is still in flight (exactly what the posix assert
+// detects), and can hold a put() to open a deterministic window. It drives two
+// server key-updates: OpenSSL only flushes the response to the first one while
+// reading the second, and that flush is the read-path put() we hold in flight
+// while a concurrent client write tries to issue the colliding put().
+//
+// The OpenSSL backend on this branch has no rehandshake/key-update entry point,
+// so the server key-updates are driven through the test-only hook
+// tls::trigger_key_update_for_test() (defined in src/net/ossl.cc).
+#ifndef SEASTAR_USE_GNUTLS
+namespace seastar::tls { future<> trigger_key_update_for_test(connected_socket&); }
+#endif
+SEASTAR_THREAD_TEST_CASE(test_concurrent_put_with_key_update) {
+#ifdef SEASTAR_USE_GNUTLS
+    // GnuTLS does not emit rehandshake/key-update output from the read path, so
+    // the concurrent-put scenario does not apply (and the trigger hook is
+    // OpenSSL-only).
+    return;
+#else
+    tls::credentials_builder b;
+    b.set_x509_key_file(certfile("test.crt"), certfile("test.key"), tls::x509_crt_format::PEM).get();
+    b.set_x509_trust_file(certfile("catest.pem"), tls::x509_crt_format::PEM).get();
+    b.set_dh_level();
+    // force TLS 1.3 so that the key update rotates the session keys, which is
+    // what makes the OpenSSL read path produce output.
+    b.set_minimum_tls_version(tls::tls_version::tlsv1_3);
+
+    auto creds = b.build_certificate_credentials();
+    auto serv = b.build_server_credentials();
+
+    // State shared between the test and the instrumented client sink.
+    struct gate_state {
+        unsigned outstanding = 0;   // put()s currently in flight on the sink
+        bool overlap = false;       // a put() started while another was in flight
+        bool arm = false;           // when set, the next put() is held
+        promise<> entered;          // resolved once a put() has been held
+        promise<> release;          // resolved by the test to release the held put()
+    };
+    // gate_state is shared with the sink (lw_shared_ptr) so it outlives the test
+    // body. session::close() tears the connection down via
+    // engine().run_in_background(...) -- a detached reactor task, kept alive by
+    // shared_from_this(), whose future is discarded -- so a sink put()'s finally
+    // can run on the reactor after this SEASTAR_THREAD_TEST_CASE fiber has
+    // returned and freed its stack. A reference to a stack gate would then be a
+    // use-after-return (an intermittent SEGV under ASan). There is no awaitable
+    // teardown to drain instead; see the commit message for the full rationale.
+    auto gate = make_lw_shared<gate_state>();
+
+    // A connected socket whose sink detects overlapping put()s (mirroring the
+    // posix_data_sink_impl contract) and can hold the first put() on demand.
+    class instrumented_socket_impl : public loopback_connected_socket_impl {
+    public:
+        lw_shared_ptr<gate_state> _gate;
+        instrumented_socket_impl(lw_shared_ptr<gate_state> g, lw_shared_ptr<loopback_buffer> tx, lw_shared_ptr<loopback_buffer> rx)
+            : loopback_connected_socket_impl(std::move(tx), std::move(rx))
+            , _gate(std::move(g))
+        {}
+        class sink_impl : public data_sink_impl {
+            data_sink _next;
+            lw_shared_ptr<gate_state> _gate;
+            future<> forward(std::vector<temporary_buffer<char>> bufs) {
+                if (_gate->outstanding != 0) {
+                    // Equivalent to SEASTAR_ASSERT(!_p) firing in
+                    // posix_data_sink_impl: a put() was issued while a previous
+                    // one had not yet completed.
+                    _gate->overlap = true;
+                }
+                ++_gate->outstanding;
+                future<> hold = make_ready_future<>();
+                if (_gate->arm) {
+                    _gate->arm = false;            // one-shot
+                    _gate->entered.set_value();    // announce the held put()
+                    hold = _gate->release.get_future();
+                }
+                return hold.then([this, bufs = std::move(bufs)] () mutable {
+                    return _next.put(std::move(bufs));
+                }).finally([gate = _gate] {
+                    --gate->outstanding;
+                });
+            }
+        public:
+            sink_impl(data_sink next, lw_shared_ptr<gate_state> g) : _next(std::move(next)), _gate(std::move(g)) {}
+            future<> flush() override { return _next.flush(); }
+            future<> close() override { return _next.close(); }
+            bool can_batch_flushes() const noexcept override { return false; }
+            using data_sink_impl::put;
+            future<> put(net::packet p) override {
+                return forward(p.release());
+            }
+        };
+        data_sink sink() override {
+            return data_sink(std::make_unique<sink_impl>(loopback_connected_socket_impl::sink(), _gate));
+        }
+    };
+
+    auto b1 = ::make_lw_shared<loopback_buffer>(nullptr, loopback_buffer::type::SERVER_TX);
+    auto b2 = ::make_lw_shared<loopback_buffer>(nullptr, loopback_buffer::type::CLIENT_TX);
+    auto ssi = std::make_unique<loopback_connected_socket_impl>(b1, b2);
+    auto csi = std::make_unique<instrumented_socket_impl>(gate, b2, b1);
+
+    auto server = tls::wrap_server(serv, connected_socket(std::move(ssi))).get();
+    auto client = tls::wrap_client(creds, connected_socket(std::move(csi))).get();
+
+    auto cin = client.input();
+    auto cout = output_stream<char>(client.output().detach(), 1024);
+    auto sin = server.input();
+    auto sout = output_stream<char>(server.output().detach(), 1024);
+
+    auto exchange = [&](output_stream<char>& out, input_stream<char>& in, const char* msg) {
+        out.write(msg).get();
+        auto fin = in.read();
+        out.flush().get();
+        return fin.get();
+    };
+
+    // Complete the handshake and exchange data both ways so both sides are
+    // fully connected and the client's output is idle before we arm the trap.
+    exchange(cout, sin, "hello");
+    exchange(sout, cin, "hello");
+
+    // OpenSSL only flushes the key-update *response* while processing a
+    // *subsequent* incoming key-update (or on the next write). So the read
+    // path produces output only on the second key-update. Drive the first
+    // one here: the client reads it and schedules a response, but emits
+    // nothing yet.
+    tls::trigger_key_update_for_test(server).get();
+    exchange(sout, cin, "a");  // carries the 1st key-update; client schedules a response
+
+    // Queue the second key-update (plus a byte to flush it). The loopback
+    // delivers the key-update record and the data byte as separate buffers, so
+    // the client's read of the key-update returns WANT_READ *after* flushing
+    // the pending response -- meaning that flush lands as a read-path put().
+    tls::trigger_key_update_for_test(server).get();
+    sout.write("b").get();
+    sout.flush().get();
+
+    // Arm the trap: the next put() on the client socket (the flushed key-update
+    // response, emitted from the read path) will be held in flight.
+    gate->arm = true;
+
+    // Read on the client. While processing the second key-update it flushes the
+    // pending response as a put() -- which the gate holds -- then suspends in
+    // wait_for_output() awaiting it (holding _in_sem, not _out_sem).
+    auto fR = cin.read();
+    gate->entered.get_future().get();
+
+    // Now write on the client. With the read's put held in flight, the buggy
+    // code lets this write issue a second, concurrent put() on the same sink
+    // (the bug). The fixed code makes the write wait for the in-flight put.
+    auto fW = cout.write("world").then([&cout] { return cout.flush(); });
+
+    // Give the write path time to reach the point where it would issue the
+    // colliding put(). The read's put stays held, so the window stays open.
+    seastar::sleep(std::chrono::milliseconds(200)).get();
+
+    bool overlap = gate->overlap;
+
+    // Release the held put; both directions drain from here.
+    gate->release.set_value();
+
+    auto ignore = [](auto f) { try { f.get(); } catch (...) {} };
+    ignore(std::move(fW));
+    ignore(std::move(fR));
+    ignore(cout.close());
+    ignore(cin.close());
+    ignore(sout.close());
+    ignore(sin.close());
+    client.shutdown_input();
+    client.shutdown_output();
+    server.shutdown_input();
+    server.shutdown_output();
+
+    BOOST_CHECK_MESSAGE(!overlap,
+        "TLS layer issued two concurrent put()s on the underlying data_sink "
+        "(this is what trips SEASTAR_ASSERT(!_p) in posix_data_sink_impl)");
+#endif
+}


### PR DESCRIPTION
Backport of #281 (merged to `v26.2.x`) to `v25.3.x`.

Fixes the production crash from https://redpandadata.atlassian.net/browse/CORE-16383:

```
virtual future<> seastar::net::posix_data_sink_impl::put(packet): Assertion `!_p` failed.
```

### The bug

The OpenSSL TLS read and write paths use separate semaphores (`_in_sem` vs `_out_sem`) and both can write to the underlying socket: a write encrypts application data, while a read can emit a TLS key-update/renegotiation response produced inside `SSL_read_ex`. `wait_for_output()` did `std::exchange(_output_pending, make_ready_future())`, which marked `_out` "idle" while the put() was still draining; `bio_write_ex()`'s guard then issued a second, concurrent `put()` from the read path while a write-path `put()` was in flight, tripping `SEASTAR_ASSERT(!_p)` in `posix_data_sink_impl`.

The fix makes `_output_pending` a `shared_future` so `wait_for_output()` hands out an awaitable via `get_future()` without consuming/replacing the in-flight put; `available()`/`failed()` then stay truthful and both paths can await the same put. The stale `SEASTAR_ASSERT(_output_pending.available())` precondition in `do_put()` is removed. Full rationale (with the interleaving) is in the commit messages.

### Commits

1. **Add reproducer** — `test_concurrent_put_with_key_update`, which fails (overlap detected) against the current backend.
2. **Fix** — the `shared_future` change in `src/net/ossl.cc`.

### Backport notes

- On `v26.2.x` the OpenSSL backend lives in `src/net/tls_openssl.cc` and splits the write path into two `do_put()` overloads plus `do_put_one()`; on `v25.3.x` it is `src/net/ossl.cc` with a **single** `do_put(net::packet)`. The buggy pattern and fix are otherwise identical.
- On `v26.2.x` the reproducer drives key-updates through the public `tls::force_rehandshake()` (implemented there via `SSL_key_update`). On `v25.3.x` there is **no rehandshake/key-update entry point at all** (`force_rehandshake()` does not exist on this branch). Rather than add that production API, this PR adds a **minimal, test-only hook** — `session::trigger_key_update_for_test()` plus a free function `tls::trigger_key_update_for_test(connected_socket&)`, neither declared in any public header — that performs just the `SSL_key_update()` the test needs. No public API or production behavior changes.
- The test selects the backend at compile time (`SEASTAR_USE_GNUTLS`), is compiled out under GnuTLS, and its instrumented `data_sink` overrides `put(net::packet)` to match this branch's (older) `data_sink` API.

### Validation

- OpenSSL backend (`--crypto-provider OpenSSL --api-level=7`, `dev`): reproducer **fails before** the fix (overlap detected) and **passes after**; the full `tls_test` suite passes (49 cases).
- The test translation unit also compiles cleanly under the GnuTLS backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
