### PR TITLE
github: disable Alpine Linux CI on v26.1.x

### DIFF
--- a/.github/workflows/alpinelinux.yaml
+++ b/.github/workflows/alpinelinux.yaml
@@ -1,7 +1,8 @@
 name: Alpine Linux
 
 on:
-  pull_request:
+  # pull_request trigger disabled on stable release branches, see CORE-16616
+  # pull_request:
   workflow_dispatch:  # Allows manual triggering
 
 concurrency:


### PR DESCRIPTION
Alpine is a rolling release, so its CI catches compile issues early (e.g., library compat changes). That signal is useful on the development branch, where Alpine remains enabled, but is not needed on stable release branches.

This comments out the `pull_request` trigger of the Alpine workflow, keeping `workflow_dispatch` so it can still be run manually.

Ref: CORE-16616