### PR TITLE
net/tls: hold the concurrent-put reproducer's gate state by shared_ptr

### DIFF
--- a/tests/unit/tls_test.cc
+++ b/tests/unit/tls_test.cc
@@ -2243,42 +2243,51 @@ SEASTAR_THREAD_TEST_CASE(test_concurrent_put_with_key_update) {
         bool arm = false;           // when set, the next put() is held
         promise<> entered;          // resolved once a put() has been held
         promise<> release;          // resolved by the test to release the held put()
-    } gate;
+    };
+    // gate_state is shared with the sink (lw_shared_ptr) so it outlives the test
+    // body. openssl_session::close() tears the connection down via
+    // engine().run_in_background(...) -- a detached reactor task, kept alive by
+    // shared_from_this(), whose future is discarded -- so a sink put()'s finally
+    // can run on the reactor after this SEASTAR_THREAD_TEST_CASE fiber has
+    // returned and freed its stack. A reference to a stack gate would then be a
+    // use-after-return (an intermittent SEGV under ASan). There is no awaitable
+    // teardown to drain instead; see the commit message for the full rationale.
+    auto gate = make_lw_shared<gate_state>();
 
     // A connected socket whose sink detects overlapping put()s (mirroring the
     // posix_data_sink_impl contract) and can hold the first put() on demand.
     class instrumented_socket_impl : public loopback_connected_socket_impl {
     public:
-        gate_state& _gate;
-        instrumented_socket_impl(gate_state& g, lw_shared_ptr<loopback_buffer> tx, lw_shared_ptr<loopback_buffer> rx)
+        lw_shared_ptr<gate_state> _gate;
+        instrumented_socket_impl(lw_shared_ptr<gate_state> g, lw_shared_ptr<loopback_buffer> tx, lw_shared_ptr<loopback_buffer> rx)
             : loopback_connected_socket_impl(std::move(tx), std::move(rx))
-            , _gate(g)
+            , _gate(std::move(g))
         {}
         class sink_impl : public data_sink_impl {
             data_sink _next;
-            gate_state& _gate;
+            lw_shared_ptr<gate_state> _gate;
             future<> forward(std::vector<temporary_buffer<char>> bufs) {
-                if (_gate.outstanding != 0) {
+                if (_gate->outstanding != 0) {
                     // Equivalent to SEASTAR_ASSERT(!_p) firing in
                     // posix_data_sink_impl: a put() was issued while a previous
                     // one had not yet completed.
-                    _gate.overlap = true;
+                    _gate->overlap = true;
                 }
-                ++_gate.outstanding;
+                ++_gate->outstanding;
                 future<> hold = make_ready_future<>();
-                if (_gate.arm) {
-                    _gate.arm = false;             // one-shot
-                    _gate.entered.set_value();     // announce the held put()
-                    hold = _gate.release.get_future();
+                if (_gate->arm) {
+                    _gate->arm = false;            // one-shot
+                    _gate->entered.set_value();    // announce the held put()
+                    hold = _gate->release.get_future();
                 }
                 return hold.then([this, bufs = std::move(bufs)] () mutable {
                     return _next.put(std::move(bufs));
-                }).finally([this] {
-                    --_gate.outstanding;
+                }).finally([gate = _gate] {
+                    --gate->outstanding;
                 });
             }
         public:
-            sink_impl(data_sink next, gate_state& g) : _next(std::move(next)), _gate(g) {}
+            sink_impl(data_sink next, lw_shared_ptr<gate_state> g) : _next(std::move(next)), _gate(std::move(g)) {}
             future<> flush() override { return _next.flush(); }
             future<> close() override { return _next.close(); }
             bool can_batch_flushes() const noexcept override { return false; }
@@ -2342,13 +2351,13 @@ SEASTAR_THREAD_TEST_CASE(test_concurrent_put_with_key_update) {
 
     // Arm the trap: the next put() on the client socket (the flushed key-update
     // response, emitted from the read path) will be held in flight.
-    gate.arm = true;
+    gate->arm = true;
 
     // Read on the client. While processing the second key-update it flushes the
     // pending response as a put() -- which the gate holds -- then suspends in
     // wait_for_output() awaiting it (holding _in_sem, not _out_sem).
     auto fR = cin.read();
-    gate.entered.get_future().get();
+    gate->entered.get_future().get();
 
     // Now write on the client. With the read's put held in flight, the buggy
     // code lets this write issue a second, concurrent put() on the same sink
@@ -2359,10 +2368,10 @@ SEASTAR_THREAD_TEST_CASE(test_concurrent_put_with_key_update) {
     // colliding put(). The read's put stays held, so the window stays open.
     seastar::sleep(std::chrono::milliseconds(200)).get();
 
-    bool overlap = gate.overlap;
+    bool overlap = gate->overlap;
 
     // Release the held put; both directions drain from here.
-    gate.release.set_value();
+    gate->release.set_value();
 
     auto ignore = [](auto f) { try { f.get(); } catch (...) {} };
     ignore(std::move(fW));


### PR DESCRIPTION
This fixes a UAF bug in the reproducer test that I hit while backporting.

---

Test-only follow-up to #281.

`test_concurrent_put_with_key_update` keeps its `gate_state` (overlap counter + arm/release promises) on the **test fiber's stack** and decrements `gate.outstanding` from the instrumented sink's `put()` `.finally()`. That `finally` can run on the reactor **after** the `SEASTAR_THREAD_TEST_CASE` fiber has returned and freed its stack, so the reference into the dead frame is a use-after-return. ASan (debug builds, `detect_stack_use_after_return=1`) traps it as a SEGV.

Whether it fires is timing-dependent, so the original merge passed CI by luck. The same latent bug then failed the debug+OpenSSL job on the [v25.3.x backport](https://github.com/redpanda-data/seastar/pull/283) of #281 while passing on [v26.1.x](https://github.com/redpanda-data/seastar/pull/282).

### Fix

Heap-allocate `gate_state` via `lw_shared_ptr`, have the sink co-own it, and capture the shared_ptr in the `.finally()`. Its lifetime then extends to match the sink's. Test-only; no production code is touched.

---

### Anticipating the review questions

**Q: Why does the `finally` run after the test body returns — didn't we close/shutdown everything first?**

`openssl_session::close()` returns `void` and hands the caller no future. It runs the TLS bye-handshake + `_in.close()/_out.close()` as a **detached** reactor task (`src/net/tls_openssl.cc`):

```cpp
void close() noexcept override {
    ...
    auto me = shared_from_this();
    engine().run_in_background(std::move(f)
        .finally([this]{ _eof = true; return _in.close(); })
        .finally([this]{ return _out.close(); })   // closes the sink
        ...
        .handle_exception([me = std::move(me)](std::exception_ptr){})
        .discard_result());
}
```

The session keeps itself (and the sink) alive via `shared_from_this()` and `discard_result()`s the future, so this task can run for up to `bye_timeout` (~10s) after `close()` returns. Tearing the sink down (`_out.close()`) can complete an in-flight `put()` whose `.finally` then runs on the reactor — after the test fiber is gone. (`shutdown_input()/shutdown_output()` are also `void`.)

**Q: Then can't we just wait/drain before the test returns instead of changing the gate?**

No clean way. There is deliberately **no future to await** (`close()` is `void` + `run_in_background` + `discard_result`) and no test-visible "fully torn down" signal. A poll like `while (gate.outstanding) yield();` races the detached task: it can issue a sink `put()` at any point in its window, including after the poll observes zero. So a drain would re-introduce exactly the timing-dependence we're removing.

**Q: If the teardown outlives the caller, isn't that inherently unsafe?**

Not for seastar's own state. The session self-owns (`enable_shared_from_this`) for the whole detached teardown, and the reactor drains `run_in_background` tasks before it stops — so the session, sink and socket are freed only once the work finishes. The only thing that's unsafe is state the *test* reached into that teardown **by raw reference** (`gate_state& _gate` → the fiber stack), whose lifetime ends at body return. That mismatch is the bug; owning the shared state by `shared_ptr` (the idiomatic rule for state captured into reactor continuations) is the fix.

**Q: How do we know this is the mechanism and not a guess?**

Confirmed deterministically (debug + ASan, `--tls-mode=openssl`):
- instrumenting the sink shows it is **destroyed after** the test body returns;
- forcing a `put()` to be in flight at body-end reproduces the exact CI SEGV in the `.finally` with the **stack** gate, while the **shared_ptr** gate runs that same late finally safely.

### Validation

`test_concurrent_put_with_key_update` and the full `tls_test` suite pass under debug + ASan (`detect_stack_use_after_return=1`), OpenSSL backend, with no SEGV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
