### PR TITLE
[v26.2.x] `core`: add `chunked_vector_async`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,6 +581,7 @@ add_library (seastar
   include/seastar/core/chunked_fifo.hh
   include/seastar/core/chunked_hash_map.hh
   include/seastar/core/chunked_vector.hh
+  include/seastar/core/chunked_vector_async.hh
   include/seastar/core/circular_buffer.hh
   include/seastar/core/circular_buffer_fixed_capacity.hh
   include/seastar/core/condition-variable.hh

--- a/include/seastar/core/chunked_vector.hh
+++ b/include/seastar/core/chunked_vector.hh
@@ -38,6 +38,19 @@
 
 namespace seastar {
 
+template <class T>
+class future;
+
+template<typename T>
+class chunked_vector;
+
+// Defined in <seastar/core/chunked_vector_async.hh>; declared here so they can
+// be befriended for direct fragment access.
+template<typename T>
+future<void> chunked_vector_fill_async(chunked_vector<T>& vec, const T& value);
+template<typename T>
+future<void> chunked_vector_clear_async(chunked_vector<T>& vec);
+
 /**
  * A chunked vector is a container that provides random access like a
  * vector, but does not store its data in contiguous memory.
@@ -563,6 +576,11 @@ private:
 
 private:
     friend class chunked_vector_validator;
+    template<typename U>
+    friend future<void>
+    chunked_vector_fill_async(chunked_vector<U>& vec, const U& value);
+    template<typename U>
+    friend future<void> chunked_vector_clear_async(chunked_vector<U>& vec);
     chunked_vector(const chunked_vector&) noexcept = default;
 
     size_t _size{0};

--- a/include/seastar/core/chunked_vector_async.hh
+++ b/include/seastar/core/chunked_vector_async.hh
@@ -1,0 +1,78 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ */
+#pragma once
+
+#include <seastar/core/chunked_vector.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/preempt.hh>
+#include <seastar/util/assert.hh>
+#include <seastar/util/later.hh>
+
+#include <algorithm>
+
+// Async helpers for chunked_vector.
+// Not in the main header to avoid pulling in all of seastar if you just need
+// chunked_vector.
+
+namespace seastar {
+
+/**
+ * A futurized version of std::fill optimized for fragmented vector. It is
+ * futurized to allow for large vectors to be filled without incurring reactor
+ * stalls. It is optimized by circumventing the indexing indirection incurred by
+ * using the fragmented vector interface directly.
+ */
+template<typename T>
+future<> chunked_vector_fill_async(chunked_vector<T>& vec, const T& value) {
+    auto remaining = vec._size;
+    for (auto& frag : vec._frags) {
+        const auto n = std::min(frag.size(), remaining);
+        if (n == 0) {
+            break;
+        }
+        std::fill_n(frag.begin(), n, value);
+        remaining -= n;
+        if (need_preempt()) {
+            co_await yield();
+        }
+    }
+    SEASTAR_ASSERT(
+      remaining == 0
+      && "chunked_vector_fill_async: fragmented vector inconsistency");
+}
+
+/**
+ * A futurized version of chunked_vector::clear that allows clearing a large
+ * vector without incurring a reactor stall.
+ */
+template<typename T>
+future<> chunked_vector_clear_async(chunked_vector<T>& vec) {
+    while (!vec._frags.empty()) {
+        vec._frags.pop_back();
+        if (need_preempt()) {
+            co_await yield();
+        }
+    }
+    vec.clear();
+}
+
+} // namespace seastar

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -329,6 +329,9 @@ seastar_add_test (chunked_hash_map
   KIND BOOST
   SOURCES chunked_hash_map_test.cc)
 
+seastar_add_test (chunked_vector_async
+  SOURCES chunked_vector_async_test.cc)
+
 seastar_add_test (linux_perf_event
   KIND BOOST
   SOURCES linux_perf_event_test.cc ../perf/linux_perf_event.cc)

--- a/tests/unit/chunked_vector_async_test.cc
+++ b/tests/unit/chunked_vector_async_test.cc
@@ -1,0 +1,71 @@
+/*
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright 2025 Redpanda Data, Inc.
+ */
+
+#include <seastar/core/chunked_vector.hh>
+#include <seastar/core/chunked_vector_async.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+using seastar::chunked_vector;
+
+SEASTAR_THREAD_TEST_CASE(chunked_vector_fill_async_test) {
+    chunked_vector<int> v;
+    chunked_vector_fill_async(v, 0).get();
+    BOOST_REQUIRE(v.size() == 0);
+
+    // fill with non-zero
+    for (int i = 1; i <= 10; ++i) {
+        v.push_back(i);
+    }
+    BOOST_REQUIRE(v.size() == 10);
+    for (const auto& e : v) {
+        BOOST_REQUIRE(e > 0);
+    }
+
+    // fill with zero
+    chunked_vector_fill_async(v, 0).get();
+    BOOST_REQUIRE(v.size() == 10);
+    for (const auto& e : v) {
+        BOOST_REQUIRE(e == 0);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(chunked_vector_clear_async_test) {
+    chunked_vector<int> v;
+    chunked_vector_clear_async(v).get();
+    BOOST_REQUIRE(v.size() == 0);
+
+    // one element
+    v.push_back(0);
+    BOOST_REQUIRE(v.size() == 1);
+    chunked_vector_clear_async(v).get();
+    BOOST_REQUIRE(v.size() == 0);
+
+    // many fragments
+    for (size_t i = 0; i < 5; ++i) {
+        for (size_t j = 0; j < v.elements_per_fragment(); ++j) {
+            v.push_back(j);
+        }
+    }
+    BOOST_REQUIRE(v.size() == (5 * v.elements_per_fragment()));
+
+    chunked_vector_clear_async(v).get();
+    BOOST_REQUIRE(v.size() == 0);
+}


### PR DESCRIPTION
Forgot to pull this in as well in https://github.com/redpanda-data/seastar/pull/289. Because we need to access private members of `chunked_vector`, it makes sense for this to be in the same repository. 