### PR TITLE
chunked_hash_{map,set}: from-range utility functions for set and hetero

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [clang++, g++]
-        standard: [20, 23]
+        standard: [23, 26]
         mode: [dev, debug, release]
     with:
       compiler: ${{ matrix.compiler }}

--- a/include/seastar/core/chunked_hash_map.hh
+++ b/include/seastar/core/chunked_hash_map.hh
@@ -91,27 +91,6 @@ using chunked_hash_map = ankerl::unordered_dense::segmented_map<
   ankerl::unordered_dense::bucket_type::standard,
   chunked_vector<ankerl::unordered_dense::bucket_type::standard>>;
 
-namespace internal {
-template<typename Range>
-struct chunked_hash_map_from_range_impl {
-    using value_t = std::ranges::range_value_t<std::decay_t<Range>>;
-    using first_t = typename value_t::first_type;
-    using second_t = typename value_t::second_type;
-    using ret_t = chunked_hash_map<first_t, second_t>;
-};
-} // namespace internal
-
-// reserves if range size is known
-template<typename Range>
-typename internal::chunked_hash_map_from_range_impl<Range>::ret_t
-chunked_hash_map_from_range(Range&& range) {
-    size_t size = 0;
-    if constexpr (std::ranges::sized_range<Range>) {
-        size = std::ranges::size(range);
-    }
-    return {std::ranges::begin(range), std::ranges::end(range), size};
-};
-
 /**
  * @brief A set counterpart of chunked_hash_map (uses a chunked vector as the
  * underlying storage).
@@ -130,6 +109,44 @@ using chunked_hash_set = ankerl::unordered_dense::segmented_set<
   chunked_vector<Key>,
   ankerl::unordered_dense::bucket_type::standard,
   chunked_vector<ankerl::unordered_dense::bucket_type::standard>>;
+
+namespace internal {
+template<typename Range>
+struct chunked_hash_map_from_range_impl {
+    using value_t = std::ranges::range_value_t<std::decay_t<Range>>;
+    using first_t = typename value_t::first_type;
+    using second_t = typename value_t::second_type;
+    using ret_t = chunked_hash_map<std::remove_cv_t<first_t>, second_t>;
+};
+} // namespace internal
+
+// reserves if range size is known
+template<typename TargetTable, typename Range>
+requires std::ranges::input_range<Range>
+    && std::convertible_to<std::ranges::range_reference_t<Range>, typename TargetTable::value_type>
+TargetTable chunked_table_from_range(Range&& range) {
+    size_t size = 0;
+    if constexpr (std::ranges::sized_range<Range>) {
+        size = std::ranges::size(range);
+    }
+    return {std::ranges::begin(range), std::ranges::end(range), size};
+}
+
+// reserves if range size is known
+template<std::ranges::input_range Range>
+auto chunked_hash_map_from_range(Range&& range) {
+    return chunked_table_from_range<
+      typename internal::chunked_hash_map_from_range_impl<Range>::ret_t>(
+      std::forward<Range>(range));
+}
+
+// reserves if range size is known
+template<std::ranges::input_range Range>
+auto chunked_hash_set_from_range(Range&& range) {
+    return chunked_table_from_range<
+      chunked_hash_set<std::ranges::range_value_t<std::decay_t<Range>>>>(
+      std::forward<Range>(range));
+}
 
 /// Returns a lower bound on the memory currently being held by `m`.
 template<

--- a/tests/unit/chunked_hash_map_test.cc
+++ b/tests/unit/chunked_hash_map_test.cc
@@ -19,6 +19,7 @@
  * Copyright 2024 Redpanda Data, Inc.
  */
 
+#include <seastar/core/sstring.hh>
 #define BOOST_TEST_MODULE chunked_hash_map
 
 #include <seastar/core/chunked_hash_map.hh>
@@ -28,11 +29,15 @@
 #include <array>
 #include <list>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
 using seastar::chunked_hash_map;
+using seastar::chunked_hash_set;
 using seastar::chunked_hash_map_from_range;
+using seastar::chunked_hash_set_from_range;
+using seastar::chunked_table_from_range;
 
 struct foo_with_std_hash {
     int a;
@@ -82,14 +87,14 @@ BOOST_AUTO_TEST_CASE(test_move_assignment) {
     other_map = std::move(map);
 }
 
-BOOST_AUTO_TEST_CASE(from_range_vector) {
+BOOST_AUTO_TEST_CASE(map_from_range_vector) {
     std::vector<std::pair<int, int>> input{{1, 10}, {2, 20}, {3, 30}};
     auto map = chunked_hash_map_from_range(input);
     chunked_hash_map<int, int> expected{{1, 10}, {2, 20}, {3, 30}};
     BOOST_REQUIRE(map == expected);
 }
 
-BOOST_AUTO_TEST_CASE(from_range_list) {
+BOOST_AUTO_TEST_CASE(map_from_range_list) {
     std::list<std::pair<std::string, int>> input{
       {"one", 1}, {"two", 2}, {"three", 3}};
     auto map = chunked_hash_map_from_range(input);
@@ -98,9 +103,41 @@ BOOST_AUTO_TEST_CASE(from_range_list) {
     BOOST_REQUIRE(map == expected);
 }
 
-BOOST_AUTO_TEST_CASE(from_range_array) {
-    std::array<std::pair<int, std::string>, 2> input{{{1, "one"}, {2, "two"}}};
+BOOST_AUTO_TEST_CASE(map_from_range_list_hetero) {
+    using hetero_map_t = chunked_hash_map<
+      std::string,
+      int,
+      ankerl::unordered_dense::hash<std::string_view>,
+      std::equal_to<std::string_view>>;
+    std::list<std::pair<seastar::sstring, int>> input{
+      {"one", 1}, {"two", 2}, {"three", 3}};
+    auto map = chunked_table_from_range<hetero_map_t>(input);
+    hetero_map_t expected{
+      {"one", 1}, {"two", 2}, {"three", 3}};
+    BOOST_REQUIRE(map == expected);
+}
+
+BOOST_AUTO_TEST_CASE(map_from_range_array) {
+    std::array<std::pair<const int, std::string>, 2> input{{{1, "one"}, {2, "two"}}};
     auto map = chunked_hash_map_from_range(input);
     chunked_hash_map<int, std::string> expected{{1, "one"}, {2, "two"}};
     BOOST_REQUIRE(map == expected);
+}
+
+BOOST_AUTO_TEST_CASE(set_from_range_vector) {
+    std::vector<std::string> input{"foo", "bar", "baz"};
+    auto set = chunked_hash_set_from_range(input);
+    chunked_hash_set<std::string> expected{"foo", "bar", "baz"};
+    BOOST_REQUIRE(set == expected);
+}
+
+BOOST_AUTO_TEST_CASE(set_from_range_vector_hetero) {
+    using hetero_set_t = chunked_hash_set<
+      std::string,
+      ankerl::unordered_dense::hash<std::string_view>,
+      std::equal_to<std::string_view>>;
+    std::vector<seastar::sstring> input{"foo", "bar", "baz"};
+    auto set = chunked_table_from_range<hetero_set_t>(input);
+    hetero_set_t expected{"foo", "bar", "baz"};
+    BOOST_REQUIRE(set == expected);
 }


### PR DESCRIPTION
Implement from-range table creation tables for
1) chunked_hash_set
2) chunked_hash_{map,set} with custom hash and eq callables