### PR TITLE
[ALT] core: use a separate syscall thread for aio fallbacks

### DIFF
--- a/include/seastar/core/reactor.hh
+++ b/include/seastar/core/reactor.hh
@@ -429,6 +429,7 @@ private:
     };
 
     signals _signals;
+    // Syscall thread for every blocking syscall except aio submission fallbacks.
     std::unique_ptr<thread_pool> _thread_pool;
     friend class internal::cpu_stall_detector;
 

--- a/src/core/reactor.cc
+++ b/src/core/reactor.cc
@@ -2696,7 +2696,11 @@ void reactor::register_metrics() {
 
     auto io_fallback_counter = [this](const sstring& reason_str, internal::thread_pool_submit_reason r) {
         static auto reason_label = sm::label("reason");
-        return sm::make_counter("io_threaded_fallbacks", std::bind(&thread_pool::count, _thread_pool.get(), r),
+        // aio_fallback work is served by the backend's aio syscall thread; every other reason by _thread_pool.
+        thread_pool* aio_pool = _backend->aio_thread_pool();
+        thread_pool* pool = (r == internal::thread_pool_submit_reason::aio_fallback && aio_pool)
+                ? aio_pool : _thread_pool.get();
+        return sm::make_counter("io_threaded_fallbacks", std::bind(&thread_pool::count, pool, r),
                 sm::description("Total number of io-threaded-fallbacks operations"), { reason_label(reason_str), });
     };
 
@@ -3143,22 +3147,32 @@ class reactor::syscall_pollfn final : public reactor::pollfn {
 public:
     syscall_pollfn(reactor& r) : _r(r) {}
     virtual bool poll() final override {
-        return _r._thread_pool->complete();
+        unsigned n = _r._thread_pool->complete();
+        if (auto* aio_pool = _r._backend->aio_thread_pool()) {
+            n += aio_pool->complete();
+        }
+        return n;
     }
     virtual bool pure_poll() override final {
         return poll(); // actually performs work, but triggers no user continuations, so okay
     }
     virtual bool try_enter_interrupt_mode() override {
         _r._thread_pool->enter_interrupt_mode();
+        if (auto* aio_pool = _r._backend->aio_thread_pool()) {
+            aio_pool->enter_interrupt_mode();
+        }
         if (poll()) {
             // raced
-            _r._thread_pool->exit_interrupt_mode();
+            exit_interrupt_mode();
             return false;
         }
         return true;
     }
     virtual void exit_interrupt_mode() override final {
         _r._thread_pool->exit_interrupt_mode();
+        if (auto* aio_pool = _r._backend->aio_thread_pool()) {
+            aio_pool->exit_interrupt_mode();
+        }
     }
 };
 

--- a/src/core/reactor_backend.cc
+++ b/src/core/reactor_backend.cc
@@ -41,6 +41,7 @@
 #include "core/reactor_backend.hh"
 #include "core/thread_pool.hh"
 #include "core/syscall_result.hh"
+#include <seastar/core/format.hh>
 #include <seastar/core/internal/buffer_allocator.hh>
 #include <seastar/util/internal/iovec_utils.hh>
 #include <seastar/core/internal/uname.hh>
@@ -119,7 +120,8 @@ aio_storage_context::iocb_pool::iocb_pool() {
 
 aio_storage_context::aio_storage_context(reactor& r)
     : _r(r)
-    , _io_context(0) {
+    , _io_context(0)
+    , _aio_thread_pool(std::make_unique<thread_pool>(seastar::format("syscall-aio-{}", r._id), r._notify_eventfd)) {
     static_assert(max_aio >= reactor::max_queues * reactor::max_queues,
                   "Mismatch between maximum allowed io and what the IO queues can produce");
     internal::setup_aio_context(max_aio, &_io_context);
@@ -127,6 +129,8 @@ aio_storage_context::aio_storage_context(reactor& r)
 }
 
 aio_storage_context::~aio_storage_context() {
+    // Join the syscall thread before destroying the aio context it submits against.
+    _aio_thread_pool.reset();
     internal::io_destroy(_io_context);
 }
 
@@ -264,7 +268,7 @@ void aio_storage_context::schedule_retry() {
         }
         return false;
     }, [this] {
-        return _r._thread_pool->submit<syscall_result<int>>(
+        return _aio_thread_pool->submit<syscall_result<int>>(
                 internal::thread_pool_submit_reason::aio_fallback, [this] () mutable {
             auto r = io_submit(_io_context, _aio_retries.size(), _aio_retries.data());
             return wrap_syscall<int>(r);

--- a/src/core/reactor_backend.hh
+++ b/src/core/reactor_backend.hh
@@ -42,6 +42,7 @@
 namespace seastar {
 
 class reactor;
+class thread_pool;
 
 // FIXME: merge it with storage context below. At this point the
 // main thing to do is unify the iocb list
@@ -85,6 +86,10 @@ class aio_storage_context {
     pending_aio_retry_t _aio_retries;       // Currently retried iocbs
     future<> _pending_aio_retry_fut = make_ready_future<>();
     internal::linux_abi::io_event _ev_buffer[max_aio];
+    // Give AIO operations their own syscall thread. This keeps them from
+    // queuing behind unrelated blocking syscalls, which would otherwise add
+    // to their latency.
+    std::unique_ptr<thread_pool> _aio_thread_pool;
 
     bool need_to_retry() const noexcept {
         return !_pending_aio_retry.empty() || !_aio_retries.empty();
@@ -103,6 +108,8 @@ public:
     bool submit_work();
     bool can_sleep() const;
     future<> stop() noexcept;
+
+    thread_pool& aio_thread_pool() noexcept { return *_aio_thread_pool; }
 };
 
 class completion_with_iocb {
@@ -236,6 +243,9 @@ public:
 
     virtual pollable_fd_state_ptr make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) = 0;
 
+    // Syscall thread for this backend's blocking aio fallbacks, or nullptr if none.
+    virtual thread_pool* aio_thread_pool() noexcept { return nullptr; }
+
 protected:
     reactor_backend(uses_blocking_io blocking_io, supports_aio_fdatasync aio_fdatasync)
         : _blocking_io(blocking_io)
@@ -310,6 +320,8 @@ public:
 
     virtual pollable_fd_state_ptr
     make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) override;
+
+    thread_pool* aio_thread_pool() noexcept override { return &_storage_context.aio_thread_pool(); }
 };
 
 class reactor_backend_aio : public reactor_backend {
@@ -362,6 +374,8 @@ public:
 
     virtual pollable_fd_state_ptr
     make_pollable_fd_state(file_desc fd, pollable_fd::speculation speculate) override;
+
+    thread_pool* aio_thread_pool() noexcept override { return &_storage_context.aio_thread_pool(); }
 };
 
 class reactor_backend_uring;


### PR DESCRIPTION
The reactor offloads blocking syscalls onto a single syscall thread. On the linux-aio backend this thread also serves aio read/write submissions that fall back to a blocking io_submit(), so a slow or stalled file or process syscall (e.g. open, stat, fsync, waitpid) can delay aio retries queued behind it, and vice versa.

Split the work when the linux-aio backend is in use. A dedicated syscall thread and queue now serve aio submission fallbacks, while the existing thread keeps handling every other blocking syscall. Submissions are routed by their thread_pool_submit_reason, so aio_fallback work no longer shares a queue with file and process operations. Other backends, which have no aio fallback path, keep using a single worker as before.