### PR TITLE
[v26.1.x] json: emit {} when streaming an object with no set members

### DIFF
--- a/src/json/json_elements.cc
+++ b/src/json/json_elements.cc
@@ -149,6 +149,9 @@ public:
      * @return a string of accumulative object
      */
     future<> done() {
+        if (!open) {
+            return _s.write(json_builder::OPEN + json_builder::CLOSE);
+        }
         return _s.write(json_builder::CLOSE);
     }
 

--- a/tests/unit/json_formatter_test.cc
+++ b/tests/unit/json_formatter_test.cc
@@ -113,6 +113,15 @@ void formatter_check_expected(sstring expected, F f, bool close = true) {
 }
 
 
+SEASTAR_THREAD_TEST_CASE(test_stream_empty_object) {
+    object_json obj;
+    BOOST_CHECK_EQUAL("{}", formatter::to_json(obj));
+    formatter_check_expected("{}", [] (auto& out) {
+        auto writer = stream_object(object_json{});
+        writer(std::move(out)).get();
+    }, false);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_stream_range_as_array) {
     sstring expected = R"([{"subject":"1","values":[1]}, {"subject":"2","values":[2]}, {"subject":"3","values":[3]}])";
     formatter_check_expected(expected, [] (auto& out) {


### PR DESCRIPTION
json_stream_builder writes the opening brace lazily, when the first set member is added, but done() writes the closing brace unconditionally. A json_base object whose members are all unset therefore streams as a bare "}", producing invalid JSON. The eager json_builder used by to_json() opens the object in its constructor and is unaffected, so the streaming and eager paths disagree.

Fix done() to emit a complete empty object when no member was ever added, matching to_json(), and add a regression test.

(cherry picked from commit 46dcd654d0182596e0395002f5d9e0d1d18aa521)