### PR TITLE
[v26.1.x] dns: fix build with c-ares 1.34.7 constified host callback

### DIFF
--- a/src/net/dns.cc
+++ b/src/net/dns.cc
@@ -44,6 +44,7 @@
 #include <arpa/nameser.h>
 #include <chrono>
 #include <memory>
+#include <concepts>
 
 #include <ares.h>
 #include <boost/lexical_cast.hpp>
@@ -597,7 +598,10 @@ dns_resolver::impl::get_host_by_addr(inet_address addr) {
 
     dns_call call(*this);
 
-    ares_gethostbyaddr(_channel, p->addr.data(), p->addr.size(), int(p->addr.in_family()), [](void* arg, int status, int timeouts, ::hostent* host) {
+    // c-ares 1.34.7 constified the hostent argument to ares_host_callback (upstream
+    // PR #1060), but 1.34.8 reverted it. Rather than key on the version, use a template
+    // that matches both variants.
+    ares_gethostbyaddr(_channel, p->addr.data(), p->addr.size(), int(p->addr.in_family()), [](void* arg, int status, int timeouts, std::convertible_to<const ::hostent*> auto host) {
         // we do potentially allocating operations below, so wrap the pointer in a
         // unique here.
         std::unique_ptr<promise_wrap> p(reinterpret_cast<promise_wrap *>(arg));


### PR DESCRIPTION
Cherry-pick of df311aa0acef00e896deeee6f209c64150d35427 from v26.3.x.

c-ares 1.34.7 constified the `hostent*` parameter of `ares_host_callback`.
The lambda passed to `ares_gethostbyaddr()` in `get_host_by_addr()` took a
non-const `::hostent*`, so it no longer converts to the expected callback
type, breaking the build with c-ares 1.34.7. This branch needs the same fix
to unblock the Redpanda c-ares CVE-2026-33630 backport (redpanda-data/redpanda#31465).